### PR TITLE
fix: refine assessment progress UX and update developer setup

### DIFF
--- a/docs/development/setup.md
+++ b/docs/development/setup.md
@@ -60,24 +60,24 @@ make dev-frontend  # http://localhost:3000
 | Target | Command | Description |
 |--------|---------|-------------|
 | `make dev` | `make -j2 dev-backend dev-frontend` | Start both servers concurrently |
-| `make dev-backend` | `uvicorn app.main:app --reload --port 8000` | Start backend with hot reload |
-| `make dev-frontend` | `npm run dev` | Start frontend dev server |
+| `make dev-backend` | `cd backend && uvicorn app.main:app --reload --port 8000` | Start backend with hot reload |
+| `make dev-frontend` | `cd frontend && npm run dev` | Start frontend dev server |
 | `make install` | `make install-backend install-frontend install-hooks` | Install all dependencies and pre-commit hooks |
-| `make install-backend` | `pip install -r requirements.txt` | Install Python dependencies |
-| `make install-frontend` | `npm install` | Install Node dependencies |
+| `make install-backend` | `cd backend && pip install -r requirements.txt` | Install Python dependencies |
+| `make install-frontend` | `cd frontend && npm install` | Install Node dependencies |
 | `make check` | `make lint typecheck test fmt-check build-frontend` | Run all checks (mirrors CI) |
 | `make lint` | `make lint-backend lint-frontend` | Lint both codebases |
-| `make lint-backend` | `ruff check .` | Lint Python code |
-| `make lint-frontend` | `npx eslint .` | Lint TypeScript code |
-| `make typecheck` | `npx tsc --noEmit` | TypeScript type checking |
+| `make lint-backend` | `cd backend && ruff check .` | Lint Python code |
+| `make lint-frontend` | `cd frontend && npx eslint .` | Lint TypeScript code |
+| `make typecheck` | `cd frontend && npx tsc --noEmit` | TypeScript type checking |
 | `make test` | `make test-backend test-frontend` | Run all tests (backend + frontend) |
-| `make test-backend` | `pytest tests/ -v` | Run backend tests |
-| `make test-frontend` | `npm test` | Run frontend tests (Vitest) |
+| `make test-backend` | `cd backend && pytest tests/ -v` | Run backend tests |
+| `make test-frontend` | `cd frontend && npm test` | Run frontend tests (Vitest) |
 | `make fmt` | `cd backend && ruff format . && ruff check --fix .` | Format Python code |
 | `make fmt-backend` | `cd backend && ruff format . && ruff check --fix .` | Format Python code (backend only) |
 | `make fmt-check` | `make fmt-check-backend` | Check Python formatting (no changes) |
 | `make fmt-check-backend` | `cd backend && ruff format --check .` | Verify Python code is formatted |
-| `make build-frontend` | `npm run build` | Build frontend for production |
+| `make build-frontend` | `cd frontend && npm run build` | Build frontend for production |
 | `make install-hooks` | `pip install pre-commit && pre-commit install` | Install pre-commit git hooks |
 | `make pre-commit` | `pre-commit run --all-files` | Run all pre-commit checks manually (runs Ruff, `forbid-env-files.sh`, and `lint-frontend-staged.sh`) |
 | `make generate-api` | `bash scripts/generate-api.sh` | Generate TypeScript types from OpenAPI spec |

--- a/docs/development/testing.md
+++ b/docs/development/testing.md
@@ -25,6 +25,7 @@ backend/tests/
 ├── conftest.py            # Shared fixtures
 ├── test_agents.py         # LLM agent tests
 ├── test_db.py             # Database tests
+├── test_export.py         # Assessment report export tests
 ├── test_health.py         # Health endpoint tests
 ├── test_knowledge_base.py # Knowledge base loader and mapper tests
 ├── test_pipeline.py       # LangGraph pipeline tests

--- a/frontend/src/app/assess/page.test.tsx
+++ b/frontend/src/app/assess/page.test.tsx
@@ -1,0 +1,89 @@
+import { render, screen } from "@testing-library/react";
+import { vi } from "vitest";
+import type { AssessmentProgress } from "@/hooks/useAssessmentChat";
+
+const mockPush = vi.fn();
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: mockPush }),
+}));
+
+const mockSendMessage = vi.fn();
+const mockInitialiseChat = vi.fn();
+let mockProgress: AssessmentProgress | null = null;
+
+vi.mock("@/hooks/useAssessmentChat", () => ({
+  useAssessmentChat: () => ({
+    messages: [{ id: "1", role: "assistant", content: "Hello" }],
+    sendMessage: mockSendMessage,
+    status: "ready",
+    error: null,
+    initialiseChat: mockInitialiseChat,
+    sessionId: "test-session",
+    progress: mockProgress,
+  }),
+}));
+
+vi.mock("@/lib/store", () => ({
+  useAppStore: () => ({
+    selectedSkillIds: ["skill-1"],
+    setProficiencyScores: vi.fn(),
+    setCurrentStep: vi.fn(),
+    setAssessmentSessionId: vi.fn(),
+    targetLevel: "intermediate",
+    selectedRoleId: null,
+  }),
+}));
+
+import AssessPage from "./page";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockProgress = null;
+  Element.prototype.scrollIntoView = vi.fn();
+});
+
+describe("AssessPage progress bar", () => {
+  it("shows numeric percentage for normal assessment progress", () => {
+    mockProgress = { type: "assessment", totalQuestions: 9, maxQuestions: 25 };
+    render(<AssessPage />);
+
+    // Question 10 of ~25 → 40%
+    expect(screen.getByText("Question 10 of ~25")).toBeInTheDocument();
+    expect(screen.getByText("40%")).toBeInTheDocument();
+  });
+
+  it("shows 'Almost done' when assessment overflows maxQuestions", () => {
+    mockProgress = { type: "assessment", totalQuestions: 25, maxQuestions: 25 };
+    render(<AssessPage />);
+
+    // Question 26 of ~25 → 104%, should show "Almost done" instead
+    expect(screen.getByText("Question 26 of ~25")).toBeInTheDocument();
+    expect(screen.getByText("Almost done")).toBeInTheDocument();
+    expect(screen.queryByText(/104%/)).not.toBeInTheDocument();
+
+    // Progress bar indicator style should be capped at 95%
+    const indicator = document.querySelector("[data-slot='progress-indicator']");
+    expect(indicator).toHaveStyle({ transform: `translateX(-${100 - 95}%)` });
+  });
+
+  it("shows 'Almost done' at exactly 95% threshold", () => {
+    // totalQuestions=22, maxQuestions=24 → (23/24)*100 ≈ 95.83% → >= 95
+    mockProgress = { type: "assessment", totalQuestions: 22, maxQuestions: 24 };
+    render(<AssessPage />);
+
+    expect(screen.getByText("Almost done")).toBeInTheDocument();
+    expect(screen.queryByText(/96%/)).not.toBeInTheDocument();
+
+    const indicator = document.querySelector("[data-slot='progress-indicator']");
+    expect(indicator).toHaveStyle({ transform: `translateX(-${100 - 95}%)` });
+  });
+
+  it("shows numeric percentage for calibration progress (unaffected)", () => {
+    mockProgress = { type: "calibration", step: 2, totalSteps: 3 };
+    render(<AssessPage />);
+
+    expect(screen.getByText("Calibration: Step 2 of 3")).toBeInTheDocument();
+    expect(screen.getByText("67%")).toBeInTheDocument();
+    expect(screen.queryByText("Almost done")).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/app/assess/page.tsx
+++ b/frontend/src/app/assess/page.tsx
@@ -108,30 +108,39 @@ export default function AssessPage() {
         </div>
 
         {/* Progress Bar */}
-        {progress && !assessmentDone && (
-          <div className="border-b border-border px-4 py-2 sm:px-6">
-            <div className="flex items-center justify-between text-xs text-muted-foreground mb-1.5">
-              <span>
-                {progress.type === "calibration"
-                  ? `Calibration: Step ${progress.step ?? 1} of ${progress.totalSteps ?? 3}`
-                  : `Question ${(progress.totalQuestions ?? 0) + 1} of ~${progress.maxQuestions ?? 25}`}
-              </span>
-              <span>
-                {progress.type === "calibration"
-                  ? `${Math.round(((progress.step ?? 1) / (progress.totalSteps ?? 3)) * 100)}%`
-                  : `${Math.round((((progress.totalQuestions ?? 0) + 1) / (progress.maxQuestions ?? 25)) * 100)}%`}
-              </span>
+        {progress && !assessmentDone && (() => {
+          const assessmentPercent = progress.type === "assessment"
+            ? (((progress.totalQuestions ?? 0) + 1) / (progress.maxQuestions ?? 25)) * 100
+            : 0;
+          const isOverflowing = progress.type === "assessment" && assessmentPercent >= 95;
+
+          return (
+            <div className="border-b border-border px-4 py-2 sm:px-6">
+              <div className="flex items-center justify-between text-xs text-muted-foreground mb-1.5">
+                <span>
+                  {progress.type === "calibration"
+                    ? `Calibration: Step ${progress.step ?? 1} of ${progress.totalSteps ?? 3}`
+                    : `Question ${(progress.totalQuestions ?? 0) + 1} of ~${progress.maxQuestions ?? 25}`}
+                </span>
+                <span>
+                  {progress.type === "calibration"
+                    ? `${Math.round(((progress.step ?? 1) / (progress.totalSteps ?? 3)) * 100)}%`
+                    : isOverflowing
+                      ? "Almost done"
+                      : `${Math.round(assessmentPercent)}%`}
+                </span>
+              </div>
+              <Progress
+                value={
+                  progress.type === "calibration"
+                    ? ((progress.step ?? 1) / (progress.totalSteps ?? 3)) * 100
+                    : Math.min(assessmentPercent, 95)
+                }
+                className="h-1.5"
+              />
             </div>
-            <Progress
-              value={
-                progress.type === "calibration"
-                  ? ((progress.step ?? 1) / (progress.totalSteps ?? 3)) * 100
-                  : (((progress.totalQuestions ?? 0) + 1) / (progress.maxQuestions ?? 25)) * 100
-              }
-              className="h-1.5"
-            />
-          </div>
-        )}
+          );
+        })()}
 
         {assessmentDone ? (
           <div className="flex-1 overflow-y-auto">


### PR DESCRIPTION

## Summary

- Update Makefile documentation to include directory navigation for backend and frontend commands, ensuring they run correctly from the project root.
- Implement an "Almost done" state and 95% visual cap for the assessment progress bar to gracefully handle sessions that exceed the estimated question count.
- Add a new test suite for the assessment page to verify progress calculation and display logic.
- Update testing documentation to include the newly added assessment report export tests.


## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Knowledge base contribution
- [x] Documentation
- [ ] Infrastructure / CI
- [x] Refactoring

## Related Issues

Closes #41 

## Checklist

- [x] I have run `make check` and all checks pass
- [x] I have added tests for new functionality
- [x] I have updated documentation if needed
- [x] My changes do not introduce new warnings
