### PR TITLE
refactor: simplify onboarding UI and update architecture documentation

### DIFF
--- a/docs/architecture/assessment-pipeline.md
+++ b/docs/architecture/assessment-pipeline.md
@@ -80,6 +80,8 @@ The core loop generates questions, evaluates responses, updates the knowledge gr
 | `evaluate_response` | `response_evaluator.evaluate_response` | Evaluates accuracy, depth, and demonstrated Bloom level |
 | `update_graph` | `knowledge_mapper.update_knowledge_graph` | Updates knowledge graph node with weighted confidence |
 
+> The assessment loop also uses routing nodes (`handle_deeper`, `handle_pivot`) and probe nodes (`probe_question`, `await_probe_response`) described in Phase 3 below.
+
 ### Question Generation
 
 The question generator receives:
@@ -173,7 +175,7 @@ The starting Bloom level for the new topic is determined by the calibrated level
 
 ### Gap Analysis
 
-**Source**: `backend/app/agents/gap_analyzer.py`
+**Source**: `backend/app/agents/gap_analyzer.py` → `analyze_gaps()`
 
 Pure Python (no LLM call). Compares the current knowledge graph against the target graph:
 
@@ -182,7 +184,7 @@ Pure Python (no LLM call). Compares the current knowledge graph against the targ
 
 ### Learning Plan Generation
 
-**Source**: `backend/app/agents/plan_generator.py`
+**Source**: `backend/app/agents/plan_generator.py` → `generate_plan()`
 
 Claude generates a phased learning plan from the gap nodes:
 

--- a/docs/architecture/data-models.md
+++ b/docs/architecture/data-models.md
@@ -124,6 +124,9 @@ class AssessmentStartRequest(CamelModel):
     target_level: str = "mid"
     role_id: str | None = None  # Validated: must be in list_domains() or None
 
+class AssessmentRespondRequest(CamelModel):
+    response: str
+
 class AssessmentStartResponse(CamelModel):
     session_id: str
     question: str

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -146,9 +146,10 @@ OpenLearning/
 ├── frontend/
 │   ├── src/
 │   │   ├── app/                 # Next.js App Router pages
-│   │   ├── components/          # UI components (shadcn/ui based)
+│   │   ├── components/
+│   │   │   ├── providers/       # React context providers (auth)
+│   │   │   └── ui/              # UI primitives (shadcn/ui)
 │   │   ├── hooks/               # Custom React hooks (useAuth, useAssessmentChat, etc.)
-│   │   ├── providers/           # React context providers (auth)
 │   │   └── lib/                 # Types, Zustand store, auth store, API client, generated types
 │   ├── Dockerfile               # Frontend container image
 │   ├── .dockerignore            # Docker build exclusions

--- a/frontend/src/app/page.test.tsx
+++ b/frontend/src/app/page.test.tsx
@@ -56,13 +56,12 @@ describe("OnboardingPage", () => {
     expect(screen.getByText(/No signup required/i)).toBeInTheDocument();
   });
 
-  it("renders bottom bar 'Try Demo' link pointing to /demo/assess", () => {
+  it("does not render 'Try Demo' link in bottom bar", () => {
     render(<OnboardingPage />);
-    const links = screen.getAllByRole("link", { name: /Try Demo/i });
+    const links = screen.queryAllByRole("link", { name: /Try Demo/i });
     const bottomBarLink = links.find(
       (link) => link.textContent?.trim() === "Try Demo"
     );
-    expect(bottomBarLink).toBeInTheDocument();
-    expect(bottomBarLink).toHaveAttribute("href", "/demo/assess");
+    expect(bottomBarLink).toBeUndefined();
   });
 });

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -9,7 +9,7 @@ import { Button } from "@/components/ui/button";
 import { useAppStore } from "@/lib/store";
 import { Skill } from "@/lib/types";
 import { api } from "@/lib/api";
-import { ArrowRight, FlaskConical, Play } from "lucide-react";
+import { ArrowRight, Play } from "lucide-react";
 import Link from "next/link";
 import { motion } from "motion/react";
 
@@ -62,7 +62,7 @@ export default function OnboardingPage() {
       !selectedSkillIds.every((id) => roleSkillIds.includes(id)));
 
   return (
-    <PageShell currentStep={0}>
+    <PageShell>
       <div className="grid gap-10 lg:grid-cols-2 lg:gap-16">
         {/* Left: Hero */}
         <motion.div
@@ -164,14 +164,6 @@ export default function OnboardingPage() {
       >
         <div className="mx-auto flex max-w-7xl items-center justify-between px-4 py-4 sm:px-6">
           <div className="flex items-center gap-3 text-sm text-muted-foreground">
-            <Link
-              href="/demo/assess"
-              className="flex items-center gap-1.5 rounded-md border border-border px-2 py-1 text-xs font-mono text-muted-foreground transition-colors hover:text-foreground"
-              title="Try a demo with pre-loaded data (no API key needed)"
-            >
-              <FlaskConical className="h-3 w-3" />
-              Try Demo
-            </Link>
             {selectedSkillIds.length === 0 ? (
               "Select at least 1 skill to continue"
             ) : (

--- a/frontend/src/components/layout/PageShell.test.tsx
+++ b/frontend/src/components/layout/PageShell.test.tsx
@@ -24,24 +24,24 @@ describe("PageShell", () => {
     useAuthStore.setState({ user: null, isLoading: false });
   });
 
-  it("renders 'Try Demo' link when isDemo is false", () => {
+  it("does not render 'Try Demo' link in header", () => {
     render(
       <PageShell currentStep={0}>
         <div>content</div>
       </PageShell>
     );
-    const link = screen.getByRole("link", { name: /Try Demo/i });
-    expect(link).toBeInTheDocument();
-    expect(link).toHaveAttribute("href", "/demo/assess");
+    expect(screen.queryByRole("link", { name: /Try Demo/i })).not.toBeInTheDocument();
   });
 
-  it("does not render 'Try Demo' link when isDemo is true", () => {
+  it("hides stepper when currentStep is not provided", () => {
     render(
-      <PageShell currentStep={0} isDemo>
+      <PageShell>
         <div>content</div>
       </PageShell>
     );
-    expect(screen.queryByRole("link", { name: /Try Demo/i })).not.toBeInTheDocument();
+    // StepProgress labels should not appear when currentStep is undefined
+    expect(screen.queryByText("Skills")).not.toBeInTheDocument();
+    expect(screen.queryByText("Assess")).not.toBeInTheDocument();
   });
 
   it("renders 'Demo' badge when isDemo is true", () => {

--- a/frontend/src/components/layout/PageShell.tsx
+++ b/frontend/src/components/layout/PageShell.tsx
@@ -3,13 +3,12 @@
 import { StepProgress, type StepDefinition } from "./StepProgress";
 import { motion } from "motion/react";
 import Image from "next/image";
-import Link from "next/link";
-import { Play, LogOut, Github } from "lucide-react";
+import { LogOut, Github } from "lucide-react";
 import { useAuthStore } from "@/lib/auth-store";
 import { useAuth } from "@/hooks/useAuth";
 
 interface PageShellProps {
-  currentStep: number;
+  currentStep?: number;
   children: React.ReactNode;
   maxWidth?: string;
   noPadding?: boolean;
@@ -36,27 +35,17 @@ export function PageShell({
             <h1 className="font-heading text-lg font-bold tracking-tight">
               <span className="text-cyan">Open</span>Learning
             </h1>
-            {isDemo ? (
+            {isDemo && (
               <span className="rounded border border-amber-500/50 bg-amber-500/10 px-1.5 py-0.5 text-[10px] font-mono font-semibold uppercase tracking-wider text-amber-400">
                 Demo
               </span>
-            ) : (
-              <>
-                <span className="hidden text-xs text-muted-foreground font-mono sm:block">
-                  session resets on close
-                </span>
-                <Link
-                  href="/demo/assess"
-                  className="inline-flex h-8 items-center gap-1.5 rounded-full bg-cyan-400 px-3.5 text-[13px] font-semibold text-[#0a0a1a] shadow-[0_0_12px_rgba(34,211,238,0.35)] transition-all duration-200 hover:shadow-[0_0_20px_rgba(34,211,238,0.5)] hover:brightness-110"
-                >
-                  <Play className="h-3 w-3 fill-current" />
-                  Try Demo
-                </Link>
-              </>
             )}
           </div>
 
           <div className="flex items-center gap-4">
+            {currentStep !== undefined && (
+              <StepProgress currentStep={currentStep} steps={steps} />
+            )}
             {!isDemo && (
               <div className="flex items-center gap-2">
                 {isLoading ? (
@@ -94,7 +83,6 @@ export function PageShell({
                 )}
               </div>
             )}
-            <StepProgress currentStep={currentStep} steps={steps} />
           </div>
         </div>
       </header>


### PR DESCRIPTION

## Summary

- Remove "Try Demo" links and icons from the onboarding page and global header.
- Make the progress stepper in `PageShell` optional and update associated tests to support non-linear page layouts.
- Update architecture documentation to include specific agent function names (`analyze_gaps`, `generate_plan`) and routing node context.
- Sync the frontend directory structure in `overview.md` with the current implementation.
- Add the `AssessmentRespondRequest` model to the data-models documentation.


## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Knowledge base contribution
- [x] Documentation
- [ ] Infrastructure / CI
- [x] Refactoring

## Related Issues

Closes #

## Checklist

- [x] I have run `make check` and all checks pass
- [x] I have added tests for new functionality
- [x] I have updated documentation if needed
- [x] My changes do not introduce new warnings
