### PR TITLE
feat: implement learning content generation pipeline (#85)

### DIFF
--- a/.claude/skills/doc-sync/SKILL.md
+++ b/.claude/skills/doc-sync/SKILL.md
@@ -5,7 +5,7 @@ description: Verify documentation accuracy against the current codebase
 
 # Documentation Sync Verification
 
-Audit project documentation to ensure it accurately reflects the current codebase.
+Audit project documentation to ensure it accurately reflects the current codebase. Update Code -> Docs Mapping in this document and in .claude/agents/doc-writer.md if any discrepancies are found or new code areas are added.
 
 ## Mapping: Code → Docs
 

--- a/backend/app/agents/content_nodes.py
+++ b/backend/app/agents/content_nodes.py
@@ -1,0 +1,518 @@
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+from collections import defaultdict, deque
+from datetime import UTC, datetime
+
+from sqlalchemy import select
+
+from app.agents.schemas import BloomValidatorOutput, ContentGeneratorOutput
+from app.db import AssessmentResult, ConceptConfig, MaterialResult, get_db
+from app.graph.content_state import (
+    ContentPlan,
+    ContentSection,
+    GeneratedContent,
+    LearningMaterial,
+    LearningMaterialState,
+    LearningObjective,
+    PrioritizedGap,
+)
+from app.knowledge_base.taxonomy import (
+    BLOOM_INT,
+    BLOOM_LABELS,
+    BLOOM_VERBS,
+    TaxonomyIndex,
+    get_taxonomy_index,
+)
+from app.prompts.content import (
+    BLOOM_VALIDATOR_SYSTEM_PROMPT,
+    BLOOM_VALIDATOR_USER_PROMPT,
+    CONTENT_GENERATOR_SYSTEM_PROMPT,
+    CONTENT_GENERATOR_USER_PROMPT,
+)
+from app.services.ai import ainvoke_structured
+
+logger = logging.getLogger("openlearning.content")
+
+# Pipeline constants
+BLOOM_PASS_THRESHOLD = 0.75
+QUALITY_PASS_THRESHOLD = 0.70
+MAX_ITERATIONS = 3
+PARALLEL_GAP_LIMIT = 5
+
+
+# ---------------------------------------------------------------------------
+# Node 1: Input Reader
+# ---------------------------------------------------------------------------
+
+
+async def input_reader(state: LearningMaterialState) -> dict:
+    """Load AssessmentResult by session_id and initialize TaxonomyIndex."""
+    session_id = state["session_id"]
+
+    async for db in get_db():
+        result = await db.execute(
+            select(AssessmentResult).where(AssessmentResult.session_id == session_id)
+        )
+        row = result.scalar_one_or_none()
+        if not row:
+            raise ValueError(f"No AssessmentResult found for session_id={session_id}")
+
+        assessment_data = {
+            "session_id": row.session_id,
+            "knowledge_graph": row.knowledge_graph,
+            "gap_nodes": row.gap_nodes or [],
+            "learning_plan": row.learning_plan,
+            "proficiency_scores": row.proficiency_scores,
+        }
+
+    # Determine domain from gap nodes or fall back
+    domain = state.get("domain", "backend_engineering")
+    taxonomy = get_taxonomy_index(domain)
+
+    # Validate concept_ids exist in taxonomy
+    gap_nodes = assessment_data.get("gap_nodes", [])
+    for gap in gap_nodes:
+        concept_id = gap.get("concept", "")
+        if not taxonomy.has(concept_id):
+            logger.warning(
+                "Concept '%s' not found in taxonomy for domain '%s', skipping",
+                concept_id,
+                domain,
+            )
+
+    return {
+        "assessment_result_data": assessment_data,
+        "domain": domain,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Node 2: Gap Prioritizer
+# ---------------------------------------------------------------------------
+
+
+async def gap_prioritizer(state: LearningMaterialState) -> dict:
+    """Compute priority scores for each gap and sort descending."""
+    assessment_data = state["assessment_result_data"]
+    domain = state.get("domain", "backend_engineering")
+    taxonomy = get_taxonomy_index(domain)
+    gap_nodes = assessment_data.get("gap_nodes", [])
+
+    # Load IRT weights from DB
+    irt_weights: dict[str, float] = {}
+    async for db in get_db():
+        concept_ids = [g.get("concept", "") for g in gap_nodes]
+        if concept_ids:
+            result = await db.execute(
+                select(ConceptConfig).where(ConceptConfig.concept_id.in_(concept_ids))
+            )
+            for row in result.scalars():
+                irt_weights[row.concept_id] = row.irt_weight
+
+    prioritized: list[PrioritizedGap] = []
+    for gap in gap_nodes:
+        concept_id = gap.get("concept", "")
+        if not taxonomy.has(concept_id):
+            continue
+
+        current_confidence = gap.get("confidence", 0.0)
+        current_bloom_str = gap.get("bloom_level", "remember")
+        current_bloom = BLOOM_INT.get(current_bloom_str, 1)
+        target_bloom = taxonomy.bloom_target_int(concept_id)
+        if target_bloom <= current_bloom:
+            continue  # No bloom gap — skip
+        bloom_distance = target_bloom - current_bloom
+        severity = taxonomy.gap_severity(concept_id, current_confidence)
+        weight = taxonomy.irt_weight(concept_id, irt_weights.get(concept_id))
+        priority_score = severity * bloom_distance * weight
+
+        evidence = gap.get("evidence", [])
+        prerequisites = taxonomy.prereqs(concept_id)
+
+        prioritized.append(
+            PrioritizedGap(
+                concept_id=concept_id,
+                current_bloom=current_bloom,
+                target_bloom=target_bloom,
+                bloom_distance=bloom_distance,
+                gap_severity=severity,
+                irt_weight=weight,
+                priority_score=priority_score,
+                evidence=evidence,
+                prerequisites=prerequisites,
+            )
+        )
+
+    prioritized.sort(key=lambda g: g.priority_score, reverse=True)
+    return {"prioritized_gaps": prioritized}
+
+
+# ---------------------------------------------------------------------------
+# Node 3: Objective Generator
+# ---------------------------------------------------------------------------
+
+
+def _topological_sort(concept_ids: list[str], taxonomy: TaxonomyIndex) -> list[str]:
+    """Kahn's algorithm for topological sort based on prerequisite edges."""
+    concept_set = set(concept_ids)
+
+    # Build adjacency list and in-degree count (only within the gap set)
+    in_degree: dict[str, int] = defaultdict(int)
+    adjacency: dict[str, list[str]] = defaultdict(list)
+    for cid in concept_ids:
+        in_degree.setdefault(cid, 0)
+        for prereq in taxonomy.prereqs(cid):
+            if prereq in concept_set:
+                adjacency[prereq].append(cid)
+                in_degree[cid] += 1
+
+    queue: deque[str] = deque(cid for cid in concept_ids if in_degree[cid] == 0)
+    result: list[str] = []
+
+    while queue:
+        node = queue.popleft()
+        result.append(node)
+        for dependent in adjacency[node]:
+            in_degree[dependent] -= 1
+            if in_degree[dependent] == 0:
+                queue.append(dependent)
+
+    # If cycle detected, append remaining (shouldn't happen in valid data)
+    remaining = [cid for cid in concept_ids if cid not in set(result)]
+    result.extend(remaining)
+
+    return result
+
+
+async def objective_generator(state: LearningMaterialState) -> dict:
+    """Generate learning objectives with topological prerequisite ordering."""
+    prioritized_gaps = state["prioritized_gaps"]
+    domain = state.get("domain", "backend_engineering")
+    taxonomy = get_taxonomy_index(domain)
+
+    concept_ids = [g.concept_id for g in prioritized_gaps]
+    prereq_order = _topological_sort(concept_ids, taxonomy)
+
+    objectives: list[LearningObjective] = []
+    for gap in prioritized_gaps:
+        # Generate one objective per intermediate Bloom level
+        for bloom_level in range(gap.current_bloom + 1, gap.target_bloom + 1):
+            verbs = BLOOM_VERBS.get(bloom_level, ["understand"])
+            verb = verbs[0]
+            bloom_label = BLOOM_LABELS.get(bloom_level, "understand")
+            concept_name = gap.concept_id.replace("_", " ")
+
+            objective_text = f"{verb.capitalize()} {concept_name} at the {bloom_label} level"
+
+            objectives.append(
+                LearningObjective(
+                    concept_id=gap.concept_id,
+                    bloom_level=bloom_level,
+                    verb=verb,
+                    objective_text=objective_text,
+                    prereq_concept_ids=gap.prerequisites,
+                )
+            )
+
+    return {"objectives": objectives, "prereq_order": prereq_order}
+
+
+# ---------------------------------------------------------------------------
+# Node 4+5: Generate All Content (parallel across gaps)
+# ---------------------------------------------------------------------------
+
+
+async def _generate_single_content(
+    gap: PrioritizedGap,
+    objectives: list[LearningObjective],
+    taxonomy: TaxonomyIndex,
+    domain: str,
+    critique: str = "",
+) -> tuple[ContentPlan, GeneratedContent]:
+    """Generate content for a single gap (content planning + LLM generation)."""
+    # Content planning (CLT params)
+    clt = taxonomy.clt_params(gap.concept_id, gap.bloom_distance)
+    tier = taxonomy.level(gap.concept_id)
+    target_bloom_label = BLOOM_LABELS.get(gap.target_bloom, "understand")
+
+    format_hints = ["explanation"]
+    if gap.target_bloom >= 3:  # apply or higher
+        format_hints.append("code_example")
+    if gap.bloom_distance > 2:
+        format_hints.append("analogy")
+    format_hints.append("quiz")
+
+    evidence_anchors = gap.evidence if gap.evidence else ["No specific evidence available"]
+
+    plan = ContentPlan(
+        concept_id=gap.concept_id,
+        target_bloom=gap.target_bloom,
+        chunk_count=clt["chunk_count"],
+        example_count=clt["example_count"],
+        scaffolding_depth=clt["scaffolding_depth"],
+        format_hints=format_hints,
+        evidence_anchors=evidence_anchors,
+    )
+
+    # Find the highest-level objective for this concept
+    concept_objectives = [o for o in objectives if o.concept_id == gap.concept_id]
+    objective_text = (
+        concept_objectives[-1].objective_text
+        if concept_objectives
+        else (f"Understand {gap.concept_id.replace('_', ' ')}")
+    )
+
+    # Build critique section
+    critique_section = ""
+    if critique:
+        critique_section = (
+            f"PREVIOUS CRITIQUE (address these issues in this version):\n{critique}\n\n"
+        )
+
+    prompt = (
+        CONTENT_GENERATOR_SYSTEM_PROMPT
+        + "\n\n"
+        + CONTENT_GENERATOR_USER_PROMPT.format(
+            concept_id=gap.concept_id,
+            domain=domain,
+            level_tier=tier,
+            objective_text=objective_text,
+            target_bloom_label=target_bloom_label,
+            target_bloom_int=gap.target_bloom,
+            evidence_anchors="\n".join(evidence_anchors),
+            chunk_count=plan.chunk_count,
+            example_count=plan.example_count,
+            scaffolding_depth=plan.scaffolding_depth,
+            format_hints=", ".join(format_hints),
+            critique_section=critique_section,
+        )
+    )
+
+    result = await ainvoke_structured(
+        ContentGeneratorOutput,
+        prompt,
+        agent_name="content_generator",
+    )
+
+    sections = [
+        ContentSection(
+            type=s.type,
+            title=s.title,
+            body=s.body,
+            code_block=s.code_block,
+            answer=s.answer,
+        )
+        for s in result.sections
+    ]
+
+    content = GeneratedContent(
+        concept_id=gap.concept_id,
+        bloom_level=gap.target_bloom,
+        sections=sections,
+        raw_prompt=prompt,
+    )
+
+    return plan, content
+
+
+async def generate_all_content(state: LearningMaterialState) -> dict:
+    """Generate content for all gaps in parallel with semaphore."""
+    prioritized_gaps = state["prioritized_gaps"]
+    objectives = state["objectives"]
+    domain = state.get("domain", "backend_engineering")
+    taxonomy = get_taxonomy_index(domain)
+
+    semaphore = asyncio.Semaphore(PARALLEL_GAP_LIMIT)
+
+    async def generate_with_semaphore(
+        gap: PrioritizedGap,
+    ) -> tuple[str, ContentPlan, GeneratedContent]:
+        async with semaphore:
+            plan, content = await _generate_single_content(gap, objectives, taxonomy, domain)
+            return gap.concept_id, plan, content
+
+    results = await asyncio.gather(
+        *(generate_with_semaphore(gap) for gap in prioritized_gaps),
+        return_exceptions=True,
+    )
+
+    content_plans: dict[str, ContentPlan] = {}
+    raw_content: dict[str, GeneratedContent] = {}
+
+    for result in results:
+        if isinstance(result, Exception):
+            logger.error("Content generation failed: %s", result)
+            continue
+        concept_id, plan, content = result
+        content_plans[concept_id] = plan
+        raw_content[concept_id] = content
+
+    if not raw_content and prioritized_gaps:
+        raise RuntimeError(f"Content generation failed for all {len(prioritized_gaps)} gaps")
+
+    return {"content_plans": content_plans, "raw_content": raw_content}
+
+
+# ---------------------------------------------------------------------------
+# Node 6+7: Validate All Content (with per-gap retry loop)
+# ---------------------------------------------------------------------------
+
+
+async def _validate_single_content(
+    concept_id: str,
+    content: GeneratedContent,
+    objectives: list[LearningObjective],
+    taxonomy: TaxonomyIndex,
+) -> BloomValidatorOutput:
+    """Run Bloom validation on generated content for a single gap."""
+    target_bloom_label = BLOOM_LABELS.get(content.bloom_level, "understand")
+    concept_objectives = [o for o in objectives if o.concept_id == concept_id]
+    objective_text = (
+        concept_objectives[-1].objective_text
+        if concept_objectives
+        else (f"Understand {concept_id.replace('_', ' ')}")
+    )
+
+    material_json = json.dumps([s.model_dump() for s in content.sections], indent=2)
+
+    prompt = (
+        BLOOM_VALIDATOR_SYSTEM_PROMPT
+        + "\n\n"
+        + BLOOM_VALIDATOR_USER_PROMPT.format(
+            target_bloom_label=target_bloom_label,
+            target_bloom_int=content.bloom_level,
+            concept_id=concept_id,
+            objective_text=objective_text,
+            generated_material=material_json,
+        )
+    )
+
+    return await ainvoke_structured(
+        BloomValidatorOutput,
+        prompt,
+        agent_name="bloom_validator",
+    )
+
+
+async def validate_all_content(state: LearningMaterialState) -> dict:
+    """Validate all generated content with per-gap retry loop and quality gate."""
+    raw_content = state["raw_content"]
+    prioritized_gaps = state["prioritized_gaps"]
+    objectives = state["objectives"]
+    domain = state.get("domain", "backend_engineering")
+    taxonomy = get_taxonomy_index(domain)
+
+    gap_map = {g.concept_id: g for g in prioritized_gaps}
+    final_materials: dict[str, LearningMaterial] = {}
+
+    for concept_id, content in raw_content.items():
+        gap = gap_map.get(concept_id)
+        if not gap:
+            continue
+
+        current_content = content
+        iteration = 0
+        critique = ""
+
+        while True:
+            iteration += 1
+
+            validation = await _validate_single_content(
+                concept_id, current_content, objectives, taxonomy
+            )
+
+            bloom_score = validation.bloom_alignment
+            quality_score = (
+                validation.accuracy + validation.clarity + validation.evidence_alignment
+            ) / 3.0
+
+            # Quality gate
+            if bloom_score >= BLOOM_PASS_THRESHOLD and quality_score >= QUALITY_PASS_THRESHOLD:
+                # PASS
+                final_materials[concept_id] = LearningMaterial(
+                    concept_id=concept_id,
+                    target_bloom=gap.target_bloom,
+                    bloom_score=bloom_score,
+                    quality_score=quality_score,
+                    sections=current_content.sections,
+                    iteration_count=iteration,
+                    generated_at=datetime.now(UTC),
+                )
+                break
+            elif iteration >= MAX_ITERATIONS:
+                # FLAG — emit with quality flag
+                final_materials[concept_id] = LearningMaterial(
+                    concept_id=concept_id,
+                    target_bloom=gap.target_bloom,
+                    bloom_score=bloom_score,
+                    quality_score=quality_score,
+                    sections=current_content.sections,
+                    iteration_count=iteration,
+                    quality_flag="max_iterations_reached",
+                    generated_at=datetime.now(UTC),
+                )
+                logger.warning(
+                    "Quality gate: max iterations reached for concept '%s' "
+                    "(bloom=%.2f, quality=%.2f)",
+                    concept_id,
+                    bloom_score,
+                    quality_score,
+                )
+                break
+            else:
+                # RETRY — regenerate with critique
+                critique = validation.critique or "Improve Bloom alignment and quality."
+                logger.info(
+                    "Quality gate: retrying concept '%s' (iteration %d, bloom=%.2f, quality=%.2f)",
+                    concept_id,
+                    iteration,
+                    bloom_score,
+                    quality_score,
+                )
+                _, current_content = await _generate_single_content(
+                    gap, objectives, taxonomy, domain, critique=critique
+                )
+
+    # Persist to DB
+    await _persist_materials(state["session_id"], domain, final_materials)
+
+    return {"final_materials": final_materials}
+
+
+async def _persist_materials(
+    session_id: str,
+    domain: str,
+    materials: dict[str, LearningMaterial],
+) -> None:
+    """Batch insert MaterialResult rows."""
+    if not materials:
+        return
+
+    rows = []
+    for concept_id, mat in materials.items():
+        rows.append(
+            MaterialResult(
+                session_id=session_id,
+                concept_id=concept_id,
+                domain=domain,
+                bloom_score=mat.bloom_score,
+                quality_score=mat.quality_score,
+                iteration_count=mat.iteration_count,
+                quality_flag=mat.quality_flag,
+                material={
+                    "concept_id": mat.concept_id,
+                    "target_bloom": mat.target_bloom,
+                    "sections": [s.model_dump() for s in mat.sections],
+                    "bloom_score": mat.bloom_score,
+                    "quality_score": mat.quality_score,
+                    "iteration_count": mat.iteration_count,
+                },
+            )
+        )
+
+    async for db in get_db():
+        db.add_all(rows)
+        await db.commit()

--- a/backend/app/agents/schemas.py
+++ b/backend/app/agents/schemas.py
@@ -106,3 +106,41 @@ class PlanOutput(BaseModel):
     summary: str = Field(description="2-3 sentence plan overview")
     total_hours: float = Field(description="Total estimated hours for the entire plan")
     phases: list[PlanPhaseOutput] = Field(description="Ordered phases of the learning plan")
+
+
+# --- Content Generation (Learning Material Pipeline) ---
+
+
+class ContentSectionOutput(BaseModel):
+    """Output schema for a single content section."""
+
+    type: str = Field(description="Section type: explanation, code_example, analogy, quiz")
+    title: str = Field(description="Section title")
+    body: str = Field(description="Section body text (markdown)")
+    code_block: str | None = Field(default=None, description="Code block content if applicable")
+    answer: str | None = Field(default=None, description="Answer for quiz sections")
+
+
+class ContentGeneratorOutput(BaseModel):
+    """Output schema for learning content generation."""
+
+    sections: list[ContentSectionOutput] = Field(description="Generated content sections")
+
+
+class BloomValidatorOutput(BaseModel):
+    """Output schema for Bloom taxonomy validation of generated content."""
+
+    bloom_alignment: float = Field(
+        description="Does engaging with this material require the learner to operate at the target Bloom level? (0.0-1.0)"
+    )
+    accuracy: float = Field(description="Is the technical content factually correct? (0.0-1.0)")
+    clarity: float = Field(
+        description="Is the material clearly written and well-structured? (0.0-1.0)"
+    )
+    evidence_alignment: float = Field(
+        description="Does the material address the specific gaps from assessment evidence? (0.0-1.0)"
+    )
+    critique: str = Field(
+        default="",
+        description="Specific actionable critique if any score is below 0.75",
+    )

--- a/backend/app/db.py
+++ b/backend/app/db.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from collections.abc import AsyncGenerator
 from datetime import datetime
 
-from sqlalchemy import DateTime, ForeignKey, String, UniqueConstraint, func
+from sqlalchemy import DateTime, Float, ForeignKey, Integer, String, UniqueConstraint, func
 from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
 from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column, relationship
@@ -88,6 +88,41 @@ class AssessmentResult(Base):
     )
 
     session: Mapped[AssessmentSession] = relationship(back_populates="result")
+
+
+class ConceptConfig(Base):
+    __tablename__ = "concept_config"
+
+    concept_id: Mapped[str] = mapped_column(String, primary_key=True)
+    domain: Mapped[str] = mapped_column(String, nullable=False)
+    irt_weight: Mapped[float] = mapped_column(Float, default=1.0)
+    notes: Mapped[str | None] = mapped_column(String, nullable=True)
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), onupdate=func.now(), nullable=False
+    )
+
+
+class MaterialResult(Base):
+    __tablename__ = "material_results"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    session_id: Mapped[str] = mapped_column(
+        String(36), ForeignKey("assessment_sessions.session_id"), nullable=False
+    )
+    concept_id: Mapped[str] = mapped_column(String, nullable=False)
+    domain: Mapped[str] = mapped_column(String, nullable=False)
+    bloom_score: Mapped[float] = mapped_column(Float, nullable=False)
+    quality_score: Mapped[float] = mapped_column(Float, nullable=False)
+    iteration_count: Mapped[int] = mapped_column(Integer, nullable=False)
+    quality_flag: Mapped[str | None] = mapped_column(String, nullable=True)
+    material: Mapped[dict] = mapped_column(JSONB, nullable=False)
+    generated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )
+
+    __table_args__ = (
+        UniqueConstraint("session_id", "concept_id", name="uq_material_session_concept"),
+    )
 
 
 _engine = None

--- a/backend/app/graph/content_pipeline.py
+++ b/backend/app/graph/content_pipeline.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+from langgraph.graph import END, START, StateGraph
+
+from app.agents.content_nodes import (
+    gap_prioritizer,
+    generate_all_content,
+    input_reader,
+    objective_generator,
+    validate_all_content,
+)
+from app.graph.content_state import LearningMaterialState
+
+
+def build_content_graph() -> StateGraph:
+    """Build the learning content generation pipeline graph."""
+    graph = StateGraph(LearningMaterialState)
+
+    graph.add_node("input_reader", input_reader)
+    graph.add_node("gap_prioritizer", gap_prioritizer)
+    graph.add_node("objective_generator", objective_generator)
+    graph.add_node("generate_all_content", generate_all_content)
+    graph.add_node("validate_all_content", validate_all_content)
+
+    graph.add_edge(START, "input_reader")
+    graph.add_edge("input_reader", "gap_prioritizer")
+    graph.add_edge("gap_prioritizer", "objective_generator")
+    graph.add_edge("objective_generator", "generate_all_content")
+    graph.add_edge("generate_all_content", "validate_all_content")
+    graph.add_edge("validate_all_content", END)
+
+    return graph
+
+
+def compile_content_graph(checkpointer):
+    """Compile the content pipeline graph with a checkpointer.
+
+    Args:
+        checkpointer: A LangGraph checkpointer instance (e.g.
+            ``AsyncPostgresSaver`` or ``MemorySaver``).
+    """
+    graph = build_content_graph()
+    return graph.compile(checkpointer=checkpointer)

--- a/backend/app/graph/content_state.py
+++ b/backend/app/graph/content_state.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import TypedDict
+
+from pydantic import BaseModel
+
+
+class ContentSection(BaseModel):
+    type: str  # 'explanation', 'code_example', 'analogy', 'quiz'
+    title: str
+    body: str
+    code_block: str | None = None
+    answer: str | None = None
+
+
+class PrioritizedGap(BaseModel):
+    concept_id: str
+    current_bloom: int  # 1-6
+    target_bloom: int  # 1-6
+    bloom_distance: int  # target - current
+    gap_severity: float  # target_confidence - current_confidence
+    irt_weight: float  # from concept_config table
+    priority_score: float  # gap_severity * bloom_distance * irt_weight
+    evidence: list[str]
+    prerequisites: list[str]
+
+
+class LearningObjective(BaseModel):
+    concept_id: str
+    bloom_level: int
+    verb: str  # Bloom action verb for this level
+    objective_text: str
+    prereq_concept_ids: list[str]
+
+
+class ContentPlan(BaseModel):
+    concept_id: str
+    target_bloom: int
+    chunk_count: int
+    example_count: int
+    scaffolding_depth: str  # 'high' | 'medium' | 'low'
+    format_hints: list[str]
+    evidence_anchors: list[str]
+
+
+class GeneratedContent(BaseModel):
+    concept_id: str
+    bloom_level: int
+    sections: list[ContentSection]
+    raw_prompt: str
+
+
+class LearningMaterial(BaseModel):
+    concept_id: str
+    target_bloom: int
+    bloom_score: float
+    quality_score: float
+    sections: list[ContentSection]
+    iteration_count: int
+    quality_flag: str | None = None
+    generated_at: datetime
+
+
+class LearningMaterialState(TypedDict, total=False):
+    # Input
+    session_id: str
+    domain: str
+    assessment_result_data: dict  # Raw AssessmentResult row data
+
+    # Node 2: Gap Prioritizer
+    prioritized_gaps: list[PrioritizedGap]
+
+    # Node 3: Objective Generator
+    objectives: list[LearningObjective]
+    prereq_order: list[str]  # topologically sorted concept_ids
+
+    # Node 4+5: Content Generation
+    content_plans: dict[str, ContentPlan]
+    raw_content: dict[str, GeneratedContent]
+
+    # Node 6+7: Validation & Quality Gate
+    final_materials: dict[str, LearningMaterial]

--- a/backend/app/knowledge_base/taxonomy.py
+++ b/backend/app/knowledge_base/taxonomy.py
@@ -1,0 +1,139 @@
+from __future__ import annotations
+
+from math import ceil
+
+from app.knowledge_base.loader import load_knowledge_base
+from app.knowledge_base.schema import LEVEL_ORDER
+
+BLOOM_INT: dict[str, int] = {
+    "remember": 1,
+    "understand": 2,
+    "apply": 3,
+    "analyze": 4,
+    "evaluate": 5,
+    "create": 6,
+}
+
+BLOOM_LABELS: dict[int, str] = {v: k for k, v in BLOOM_INT.items()}
+
+BLOOM_VERBS: dict[int, list[str]] = {
+    1: ["define", "list", "recall", "identify", "name", "state"],
+    2: ["explain", "describe", "summarize", "paraphrase", "classify"],
+    3: ["implement", "use", "demonstrate", "execute", "solve", "write"],
+    4: ["compare", "differentiate", "examine", "deconstruct", "trace"],
+    5: ["assess", "critique", "justify", "argue", "appraise", "defend"],
+    6: ["design", "construct", "formulate", "architect", "compose"],
+}
+
+CLT_CHUNK_FACTOR: dict[str, float] = {
+    "junior": 1.0,
+    "mid": 1.2,
+    "senior": 1.5,
+    "staff": 2.0,
+}
+
+IRT_TIER_FALLBACK: dict[str, float] = {
+    "junior": 0.9,
+    "mid": 1.2,
+    "senior": 1.5,
+    "staff": 1.9,
+}
+
+_taxonomy_cache: dict[str, TaxonomyIndex] = {}
+
+
+class TaxonomyIndex:
+    """In-memory index over a domain's knowledge base for the content pipeline.
+
+    Wraps KnowledgeBaseSchema with computed accessors for gap severity,
+    Bloom targets, CLT parameters, and prerequisite lookups.
+    """
+
+    def __init__(self, domain: str) -> None:
+        self._kb = load_knowledge_base(domain)
+        self._domain = domain
+        self._concepts: dict[str, dict] = {}
+        self._level_map: dict[str, str] = {}
+
+        for level_name, level_data in self._kb.levels.items():
+            for concept_data in level_data.concepts:
+                cid = concept_data.concept
+                self._concepts[cid] = {
+                    "concept": cid,
+                    "target_confidence": concept_data.target_confidence,
+                    "bloom_target": concept_data.bloom_target,
+                    "prerequisites": concept_data.prerequisites,
+                    "level": level_name,
+                }
+                self._level_map[cid] = level_name
+
+    @property
+    def domain(self) -> str:
+        return self._domain
+
+    def has(self, concept_id: str) -> bool:
+        return concept_id in self._concepts
+
+    def get(self, concept_id: str) -> dict:
+        if concept_id not in self._concepts:
+            raise KeyError(
+                f"Concept '{concept_id}' not found in taxonomy for domain '{self._domain}'"
+            )
+        return self._concepts[concept_id]
+
+    def bloom_target_int(self, concept_id: str) -> int:
+        concept = self.get(concept_id)
+        bloom_str = concept["bloom_target"]
+        if bloom_str not in BLOOM_INT:
+            raise ValueError(f"Unknown bloom level '{bloom_str}' for concept '{concept_id}'")
+        return BLOOM_INT[bloom_str]
+
+    def gap_severity(self, concept_id: str, current_confidence: float) -> float:
+        concept = self.get(concept_id)
+        target_confidence = concept["target_confidence"]
+        return max(0.0, target_confidence - current_confidence)
+
+    def irt_weight(self, concept_id: str, db_weight: float | None = None) -> float:
+        if db_weight is not None:
+            return db_weight
+        concept = self.get(concept_id)
+        tier = concept["level"]
+        return IRT_TIER_FALLBACK.get(tier, 1.0)
+
+    def prereqs(self, concept_id: str) -> list[str]:
+        concept = self.get(concept_id)
+        return concept["prerequisites"]
+
+    def level(self, concept_id: str) -> str:
+        concept = self.get(concept_id)
+        return concept["level"]
+
+    def clt_params(self, concept_id: str, bloom_distance: int) -> dict:
+        tier = self.level(concept_id)
+        chunk_factor = CLT_CHUNK_FACTOR.get(tier, 1.0)
+        chunk_count = max(1, ceil(bloom_distance * chunk_factor))
+
+        tier_idx = LEVEL_ORDER.index(tier) if tier in LEVEL_ORDER else 0
+        example_count = 2 if tier_idx <= 1 else 3
+        scaffolding_depth = "high" if tier_idx >= 2 else "medium"
+
+        return {
+            "chunk_count": chunk_count,
+            "example_count": example_count,
+            "scaffolding_depth": scaffolding_depth,
+        }
+
+    def all_concept_ids(self) -> list[str]:
+        return list(self._concepts.keys())
+
+
+def get_taxonomy_index(domain: str) -> TaxonomyIndex:
+    """Return a cached TaxonomyIndex for the given domain."""
+    if domain not in _taxonomy_cache:
+        _taxonomy_cache[domain] = TaxonomyIndex(domain)
+    return _taxonomy_cache[domain]
+
+
+def clear_taxonomy_cache() -> None:
+    """Clear taxonomy cache. Useful for tests."""
+    _taxonomy_cache.clear()

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -14,8 +14,18 @@ from starlette.requests import Request
 
 from app.config import get_settings
 from app.db import init_db
+from app.graph.content_pipeline import compile_content_graph
 from app.graph.pipeline import compile_graph
-from app.routes import assessment, auth, gap_analysis, health, learning_plan, roles, skills
+from app.routes import (
+    assessment,
+    auth,
+    gap_analysis,
+    health,
+    learning_plan,
+    materials,
+    roles,
+    skills,
+)
 from app.services.session_cleanup import cleanup_stale_sessions
 
 settings = get_settings()
@@ -34,6 +44,7 @@ async def lifespan(app: FastAPI):
     async with AsyncPostgresSaver.from_conn_string(checkpoint_url) as checkpointer:
         await checkpointer.setup()
         app.state.graph = compile_graph(checkpointer)
+        app.state.content_graph = compile_content_graph(checkpointer)
         yield
     cleanup_task.cancel()
     with contextlib.suppress(asyncio.CancelledError):
@@ -62,6 +73,7 @@ app.include_router(assessment.router, prefix="/api")
 app.include_router(roles.router, prefix="/api")
 app.include_router(gap_analysis.router, prefix="/api")
 app.include_router(learning_plan.router, prefix="/api")
+app.include_router(materials.router, prefix="/api")
 app.include_router(auth.router, prefix="/api/auth")
 
 

--- a/backend/app/prompts/content.py
+++ b/backend/app/prompts/content.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+CONTENT_GENERATOR_SYSTEM_PROMPT = """\
+You are an expert instructional designer and software engineer.
+You generate precise, technically accurate learning material.
+You always ground explanations in concrete code examples and real evidence."""
+
+CONTENT_GENERATOR_USER_PROMPT = """\
+Generate learning material for the following gap.
+
+CONCEPT: {concept_id}
+DOMAIN: {domain} / {level_tier} level
+LEARNING OBJECTIVE: {objective_text}
+TARGET BLOOM LEVEL: {target_bloom_label} ({target_bloom_int}/6)
+
+LEARNER CONTEXT (from assessment evidence):
+{evidence_anchors}
+
+CONTENT PLAN:
+- Sections: {chunk_count}
+- Worked examples: {example_count}
+- Scaffolding depth: {scaffolding_depth}
+- Required formats: {format_hints}
+
+{critique_section}\
+Generate the material as structured JSON matching the ContentSection schema.
+Each section must include: type, title, body, and (if code) a code_block field.
+Do not include material that falls below the target Bloom level."""
+
+BLOOM_VALIDATOR_SYSTEM_PROMPT = """\
+You are a strict educational quality assessor. You evaluate learning material
+against Bloom's Taxonomy levels and instructional quality criteria.
+Respond ONLY with valid JSON. No preamble or explanation outside the JSON."""
+
+BLOOM_VALIDATOR_USER_PROMPT = """\
+Evaluate the following learning material.
+
+TARGET BLOOM LEVEL: {target_bloom_label} ({target_bloom_int}/6)
+CONCEPT: {concept_id}
+LEARNING OBJECTIVE: {objective_text}
+
+MATERIAL TO EVALUATE:
+{generated_material}
+
+Score each criterion from 0.0 to 1.0.
+
+bloom_alignment: Does engaging with this material REQUIRE the learner to
+  operate at {target_bloom_label} level? (1.0 = fully requires it,
+  0.0 = requires only lower levels)
+
+accuracy: Is the technical content factually correct for the domain?
+
+clarity: Is the material clearly written and well-structured?
+
+evidence_alignment: Does the material address the specific gaps identified
+  in the learner's assessment evidence?
+
+Respond with:
+{{
+  "bloom_alignment": 0.0-1.0,
+  "accuracy": 0.0-1.0,
+  "clarity": 0.0-1.0,
+  "evidence_alignment": 0.0-1.0,
+  "critique": "specific actionable critique if any score < 0.75"
+}}"""

--- a/backend/app/routes/assessment.py
+++ b/backend/app/routes/assessment.py
@@ -19,6 +19,7 @@ from app.knowledge_base.loader import get_target_graph, list_domains, map_skills
 from app.models.base import CamelModel
 from app.routes.export_utils import build_assessment_markdown
 from app.services.ai import api_key_scope, classify_anthropic_error
+from app.services.content_trigger import trigger_content_pipeline
 
 logger = logging.getLogger("openlearning.assessment")
 
@@ -352,6 +353,9 @@ async def assessment_report(
         if session_row:
             session_row.status = "completed"
         await db.commit()
+
+        # Trigger content generation pipeline in background
+        trigger_content_pipeline(session_id, req.app)
 
     return AssessmentReportResponse(
         knowledge_graph=KnowledgeGraphOut(

--- a/backend/app/routes/materials.py
+++ b/backend/app/routes/materials.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+from datetime import datetime
+
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.db import AssessmentSession, MaterialResult, get_db
+from app.deps import AuthUser, get_current_user
+from app.models.base import CamelModel
+
+router = APIRouter()
+
+
+class MaterialOut(CamelModel):
+    concept_id: str
+    domain: str
+    bloom_score: float
+    quality_score: float
+    iteration_count: int
+    quality_flag: str | None = None
+    material: dict
+    generated_at: datetime
+
+
+class MaterialsResponse(CamelModel):
+    session_id: str
+    materials: list[MaterialOut]
+
+
+@router.get(
+    "/materials/{session_id}",
+    response_model=MaterialsResponse,
+    response_model_by_alias=True,
+)
+async def get_materials(
+    session_id: str,
+    user: AuthUser = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+) -> MaterialsResponse:
+    """Retrieve generated learning materials for a given assessment session."""
+    # Verify session exists and belongs to requesting user
+    session_result = await db.execute(
+        select(AssessmentSession).where(AssessmentSession.session_id == session_id)
+    )
+    session_row = session_result.scalar_one_or_none()
+    if not session_row:
+        raise HTTPException(status_code=404, detail="Session not found")
+    if session_row.user_id and session_row.user_id != user.user_id:
+        raise HTTPException(status_code=404, detail="Session not found")
+
+    # Fetch materials
+    result = await db.execute(select(MaterialResult).where(MaterialResult.session_id == session_id))
+    rows = result.scalars().all()
+
+    return MaterialsResponse(
+        session_id=session_id,
+        materials=[
+            MaterialOut(
+                concept_id=row.concept_id,
+                domain=row.domain,
+                bloom_score=row.bloom_score,
+                quality_score=row.quality_score,
+                iteration_count=row.iteration_count,
+                quality_flag=row.quality_flag,
+                material=row.material,
+                generated_at=row.generated_at,
+            )
+            for row in rows
+        ],
+    )

--- a/backend/app/services/content_trigger.py
+++ b/backend/app/services/content_trigger.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+import asyncio
+import logging
+
+from fastapi import FastAPI
+from sqlalchemy import select
+
+from app.db import AssessmentSession, get_db
+from app.knowledge_base.loader import map_skills_to_domain
+
+logger = logging.getLogger("openlearning.content")
+
+_background_tasks: set[asyncio.Task] = set()
+
+
+def trigger_content_pipeline(session_id: str, app: FastAPI) -> None:
+    """Fire-and-forget background task to generate learning content for a completed assessment."""
+    task = asyncio.create_task(_run_content_pipeline(session_id, app))
+    _background_tasks.add(task)
+    task.add_done_callback(_background_tasks.discard)
+
+
+async def _run_content_pipeline(session_id: str, app: FastAPI) -> None:
+    """Run the content generation pipeline for a given session."""
+    try:
+        # Determine domain from session's skill_ids
+        domain = "backend_engineering"
+        async for db in get_db():
+            result = await db.execute(
+                select(AssessmentSession).where(AssessmentSession.session_id == session_id)
+            )
+            session_row = result.scalar_one_or_none()
+            if session_row and session_row.skill_ids:
+                domain = map_skills_to_domain(session_row.skill_ids)
+
+        content_graph = app.state.content_graph
+        config = {"configurable": {"thread_id": f"content-{session_id}"}}
+        initial_state = {"session_id": session_id, "domain": domain}
+        await content_graph.ainvoke(initial_state, config)
+        logger.info("Content pipeline completed for session %s", session_id)
+    except Exception:
+        logger.exception("Content pipeline failed for session %s", session_id)

--- a/backend/tests/test_content_nodes.py
+++ b/backend/tests/test_content_nodes.py
@@ -1,0 +1,609 @@
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from app.agents.content_nodes import (
+    MAX_ITERATIONS,
+    gap_prioritizer,
+    generate_all_content,
+    input_reader,
+    objective_generator,
+    validate_all_content,
+)
+from app.agents.schemas import BloomValidatorOutput, ContentGeneratorOutput, ContentSectionOutput
+from app.graph.content_state import (
+    ContentSection,
+    GeneratedContent,
+    LearningMaterialState,
+    PrioritizedGap,
+)
+from app.knowledge_base.taxonomy import clear_taxonomy_cache
+
+
+@pytest.fixture(autouse=True)
+def _clear_cache():
+    clear_taxonomy_cache()
+    yield
+    clear_taxonomy_cache()
+
+
+@pytest.fixture
+def sample_gap_nodes() -> list[dict]:
+    return [
+        {
+            "concept": "http_fundamentals",
+            "confidence": 0.3,
+            "bloom_level": "remember",
+            "prerequisites": [],
+            "evidence": ["Partial understanding of HTTP methods"],
+        },
+        {
+            "concept": "rest_api_basics",
+            "confidence": 0.2,
+            "bloom_level": "remember",
+            "prerequisites": ["http_fundamentals"],
+            "evidence": ["Could not explain REST principles"],
+        },
+    ]
+
+
+@pytest.fixture
+def sample_assessment_data(sample_gap_nodes: list[dict]) -> dict:
+    return {
+        "session_id": "sess-test",
+        "knowledge_graph": {"nodes": [], "edges": []},
+        "gap_nodes": sample_gap_nodes,
+        "learning_plan": None,
+        "proficiency_scores": [],
+    }
+
+
+@pytest.fixture
+def prioritized_gaps() -> list[PrioritizedGap]:
+    return [
+        PrioritizedGap(
+            concept_id="http_fundamentals",
+            current_bloom=1,
+            target_bloom=2,
+            bloom_distance=1,
+            gap_severity=0.4,
+            irt_weight=0.9,
+            priority_score=0.36,
+            evidence=["Partial understanding of HTTP methods"],
+            prerequisites=[],
+        ),
+        PrioritizedGap(
+            concept_id="rest_api_basics",
+            current_bloom=1,
+            target_bloom=3,
+            bloom_distance=2,
+            gap_severity=0.5,
+            irt_weight=0.9,
+            priority_score=0.9,
+            evidence=["Could not explain REST principles"],
+            prerequisites=["http_fundamentals"],
+        ),
+    ]
+
+
+def _mock_content_output() -> ContentGeneratorOutput:
+    return ContentGeneratorOutput(
+        sections=[
+            ContentSectionOutput(
+                type="explanation",
+                title="Understanding HTTP",
+                body="HTTP is a protocol...",
+            ),
+            ContentSectionOutput(
+                type="quiz",
+                title="Check your understanding",
+                body="What is the difference between GET and POST?",
+                answer="GET retrieves data, POST sends data.",
+            ),
+        ]
+    )
+
+
+def _mock_validator_output(
+    bloom: float = 0.9, accuracy: float = 0.9, clarity: float = 0.9, evidence: float = 0.9
+) -> BloomValidatorOutput:
+    return BloomValidatorOutput(
+        bloom_alignment=bloom,
+        accuracy=accuracy,
+        clarity=clarity,
+        evidence_alignment=evidence,
+        critique="" if bloom >= 0.75 else "Needs improvement in Bloom alignment.",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Input Reader Tests
+# ---------------------------------------------------------------------------
+
+
+class TestInputReader:
+    @pytest.mark.asyncio
+    @patch("app.agents.content_nodes.get_db")
+    async def test_loads_assessment_result(
+        self, mock_get_db: AsyncMock, setup_db, sample_assessment_data: dict
+    ) -> None:
+        from tests.conftest import _override_get_db, _TestSessionFactory, seed_result, seed_session
+
+        mock_get_db.side_effect = _override_get_db
+
+        async with _TestSessionFactory() as db:
+            await seed_session(db, "sess-test", "thread-test", "completed")
+            await seed_result(
+                db,
+                "sess-test",
+                gap_nodes=sample_assessment_data["gap_nodes"],
+            )
+
+        state: LearningMaterialState = {
+            "session_id": "sess-test",
+            "domain": "backend_engineering",
+        }
+        result = await input_reader(state)
+
+        assert "assessment_result_data" in result
+        assert result["assessment_result_data"]["session_id"] == "sess-test"
+
+    @pytest.mark.asyncio
+    @patch("app.agents.content_nodes.get_db")
+    async def test_raises_on_missing_session(self, mock_get_db: AsyncMock, setup_db) -> None:
+        from tests.conftest import _override_get_db
+
+        mock_get_db.side_effect = _override_get_db
+
+        state: LearningMaterialState = {
+            "session_id": "nonexistent",
+            "domain": "backend_engineering",
+        }
+        with pytest.raises(ValueError, match="No AssessmentResult found"):
+            await input_reader(state)
+
+
+# ---------------------------------------------------------------------------
+# Gap Prioritizer Tests
+# ---------------------------------------------------------------------------
+
+
+class TestGapPrioritizer:
+    @pytest.mark.asyncio
+    @patch("app.agents.content_nodes.get_db")
+    async def test_computes_priority_scores(
+        self, mock_get_db: AsyncMock, setup_db, sample_assessment_data: dict
+    ) -> None:
+        from tests.conftest import _override_get_db
+
+        mock_get_db.side_effect = _override_get_db
+
+        state: LearningMaterialState = {
+            "session_id": "sess-test",
+            "domain": "backend_engineering",
+            "assessment_result_data": sample_assessment_data,
+        }
+        result = await gap_prioritizer(state)
+        gaps = result["prioritized_gaps"]
+
+        assert len(gaps) == 2
+        for gap in gaps:
+            assert gap.priority_score > 0
+
+    @pytest.mark.asyncio
+    @patch("app.agents.content_nodes.get_db")
+    async def test_sorts_descending(
+        self, mock_get_db: AsyncMock, setup_db, sample_assessment_data: dict
+    ) -> None:
+        from tests.conftest import _override_get_db
+
+        mock_get_db.side_effect = _override_get_db
+
+        state: LearningMaterialState = {
+            "session_id": "sess-test",
+            "domain": "backend_engineering",
+            "assessment_result_data": sample_assessment_data,
+        }
+        result = await gap_prioritizer(state)
+        gaps = result["prioritized_gaps"]
+
+        scores = [g.priority_score for g in gaps]
+        assert scores == sorted(scores, reverse=True)
+
+
+# ---------------------------------------------------------------------------
+# Objective Generator Tests
+# ---------------------------------------------------------------------------
+
+
+class TestObjectiveGenerator:
+    @pytest.mark.asyncio
+    async def test_topological_sort(self, prioritized_gaps: list[PrioritizedGap]) -> None:
+        state: LearningMaterialState = {
+            "session_id": "sess-test",
+            "domain": "backend_engineering",
+            "prioritized_gaps": prioritized_gaps,
+        }
+        result = await objective_generator(state)
+
+        prereq_order = result["prereq_order"]
+        assert prereq_order.index("http_fundamentals") < prereq_order.index("rest_api_basics")
+
+    @pytest.mark.asyncio
+    async def test_bloom_verb_selection(self, prioritized_gaps: list[PrioritizedGap]) -> None:
+        state: LearningMaterialState = {
+            "session_id": "sess-test",
+            "domain": "backend_engineering",
+            "prioritized_gaps": prioritized_gaps,
+        }
+        result = await objective_generator(state)
+
+        objectives = result["objectives"]
+        assert len(objectives) > 0
+        for obj in objectives:
+            assert obj.verb != ""
+            assert obj.objective_text != ""
+
+    @pytest.mark.asyncio
+    async def test_intermediate_objectives(self, prioritized_gaps: list[PrioritizedGap]) -> None:
+        state: LearningMaterialState = {
+            "session_id": "sess-test",
+            "domain": "backend_engineering",
+            "prioritized_gaps": prioritized_gaps,
+        }
+        result = await objective_generator(state)
+
+        # rest_api_basics gap spans remember(1) → apply(3), should produce 2 objectives (understand, apply)
+        rest_objectives = [o for o in result["objectives"] if o.concept_id == "rest_api_basics"]
+        assert len(rest_objectives) == 2
+        assert rest_objectives[0].bloom_level == 2  # understand
+        assert rest_objectives[1].bloom_level == 3  # apply
+
+
+# ---------------------------------------------------------------------------
+# Generate All Content Tests
+# ---------------------------------------------------------------------------
+
+
+class TestGenerateAllContent:
+    @pytest.mark.asyncio
+    @patch("app.agents.content_nodes.ainvoke_structured")
+    async def test_generates_for_all_gaps(
+        self,
+        mock_ainvoke: AsyncMock,
+        prioritized_gaps: list[PrioritizedGap],
+    ) -> None:
+        mock_ainvoke.return_value = _mock_content_output()
+
+        from app.graph.content_state import LearningObjective
+
+        state: LearningMaterialState = {
+            "session_id": "sess-test",
+            "domain": "backend_engineering",
+            "prioritized_gaps": prioritized_gaps,
+            "objectives": [
+                LearningObjective(
+                    concept_id="http_fundamentals",
+                    bloom_level=2,
+                    verb="explain",
+                    objective_text="Explain HTTP fundamentals",
+                    prereq_concept_ids=[],
+                ),
+                LearningObjective(
+                    concept_id="rest_api_basics",
+                    bloom_level=3,
+                    verb="implement",
+                    objective_text="Implement REST API basics",
+                    prereq_concept_ids=["http_fundamentals"],
+                ),
+            ],
+        }
+
+        result = await generate_all_content(state)
+
+        assert "raw_content" in result
+        assert "content_plans" in result
+        assert len(result["raw_content"]) == 2
+        assert mock_ainvoke.call_count == 2
+
+    @pytest.mark.asyncio
+    @patch("app.agents.content_nodes.ainvoke_structured")
+    async def test_includes_evidence_anchors(
+        self,
+        mock_ainvoke: AsyncMock,
+        prioritized_gaps: list[PrioritizedGap],
+    ) -> None:
+        mock_ainvoke.return_value = _mock_content_output()
+
+        from app.graph.content_state import LearningObjective
+
+        state: LearningMaterialState = {
+            "session_id": "sess-test",
+            "domain": "backend_engineering",
+            "prioritized_gaps": [prioritized_gaps[0]],  # Just http_fundamentals
+            "objectives": [
+                LearningObjective(
+                    concept_id="http_fundamentals",
+                    bloom_level=2,
+                    verb="explain",
+                    objective_text="Explain HTTP fundamentals",
+                    prereq_concept_ids=[],
+                ),
+            ],
+        }
+
+        await generate_all_content(state)
+
+        # Verify the prompt passed to ainvoke contains evidence
+        call_args = mock_ainvoke.call_args
+        prompt = call_args[0][1]
+        assert "Partial understanding of HTTP methods" in prompt
+
+    @pytest.mark.asyncio
+    @patch("app.agents.content_nodes.ainvoke_structured")
+    async def test_raises_when_all_gaps_fail(
+        self,
+        mock_ainvoke: AsyncMock,
+        prioritized_gaps: list[PrioritizedGap],
+    ) -> None:
+        mock_ainvoke.side_effect = RuntimeError("LLM call failed")
+
+        from app.graph.content_state import LearningObjective
+
+        state: LearningMaterialState = {
+            "session_id": "sess-test",
+            "domain": "backend_engineering",
+            "prioritized_gaps": prioritized_gaps,
+            "objectives": [
+                LearningObjective(
+                    concept_id="http_fundamentals",
+                    bloom_level=2,
+                    verb="explain",
+                    objective_text="Explain HTTP fundamentals",
+                    prereq_concept_ids=[],
+                ),
+            ],
+        }
+
+        with pytest.raises(RuntimeError, match="Content generation failed for all"):
+            await generate_all_content(state)
+
+
+# ---------------------------------------------------------------------------
+# Quality Gate Retry Tests
+# ---------------------------------------------------------------------------
+
+
+class TestQualityGateRetry:
+    @pytest.mark.asyncio
+    @patch("app.agents.content_nodes._persist_materials")
+    @patch("app.agents.content_nodes.ainvoke_structured")
+    async def test_pass_on_first_attempt(
+        self,
+        mock_ainvoke: AsyncMock,
+        mock_persist: AsyncMock,
+        prioritized_gaps: list[PrioritizedGap],
+    ) -> None:
+        # Validator returns passing scores
+        mock_ainvoke.return_value = _mock_validator_output(bloom=0.9, accuracy=0.9)
+
+        from app.graph.content_state import LearningObjective
+
+        raw_content = {
+            "http_fundamentals": GeneratedContent(
+                concept_id="http_fundamentals",
+                bloom_level=2,
+                sections=[
+                    ContentSection(type="explanation", title="HTTP", body="explanation text")
+                ],
+                raw_prompt="test prompt",
+            ),
+        }
+
+        state: LearningMaterialState = {
+            "session_id": "sess-test",
+            "domain": "backend_engineering",
+            "prioritized_gaps": [prioritized_gaps[0]],
+            "objectives": [
+                LearningObjective(
+                    concept_id="http_fundamentals",
+                    bloom_level=2,
+                    verb="explain",
+                    objective_text="Explain HTTP fundamentals",
+                    prereq_concept_ids=[],
+                ),
+            ],
+            "raw_content": raw_content,
+        }
+
+        result = await validate_all_content(state)
+
+        materials = result["final_materials"]
+        assert "http_fundamentals" in materials
+        assert materials["http_fundamentals"].iteration_count == 1
+        assert materials["http_fundamentals"].quality_flag is None
+
+    @pytest.mark.asyncio
+    @patch("app.agents.content_nodes._persist_materials")
+    @patch("app.agents.content_nodes._generate_single_content")
+    @patch("app.agents.content_nodes._validate_single_content")
+    async def test_pass_on_retry(
+        self,
+        mock_validate: AsyncMock,
+        mock_generate: AsyncMock,
+        mock_persist: AsyncMock,
+        prioritized_gaps: list[PrioritizedGap],
+    ) -> None:
+        # First validation fails, second passes
+        mock_validate.side_effect = [
+            _mock_validator_output(bloom=0.5, accuracy=0.5),
+            _mock_validator_output(bloom=0.9, accuracy=0.9),
+        ]
+
+        # Regenerated content
+        regenerated = GeneratedContent(
+            concept_id="http_fundamentals",
+            bloom_level=2,
+            sections=[
+                ContentSection(type="explanation", title="Better HTTP", body="improved text")
+            ],
+            raw_prompt="test prompt v2",
+        )
+        mock_generate.return_value = (None, regenerated)
+
+        from app.graph.content_state import LearningObjective
+
+        raw_content = {
+            "http_fundamentals": GeneratedContent(
+                concept_id="http_fundamentals",
+                bloom_level=2,
+                sections=[
+                    ContentSection(type="explanation", title="HTTP", body="explanation text")
+                ],
+                raw_prompt="test prompt",
+            ),
+        }
+
+        state: LearningMaterialState = {
+            "session_id": "sess-test",
+            "domain": "backend_engineering",
+            "prioritized_gaps": [prioritized_gaps[0]],
+            "objectives": [
+                LearningObjective(
+                    concept_id="http_fundamentals",
+                    bloom_level=2,
+                    verb="explain",
+                    objective_text="Explain HTTP fundamentals",
+                    prereq_concept_ids=[],
+                ),
+            ],
+            "raw_content": raw_content,
+        }
+
+        result = await validate_all_content(state)
+
+        materials = result["final_materials"]
+        assert materials["http_fundamentals"].iteration_count == 2
+        assert materials["http_fundamentals"].quality_flag is None
+
+    @pytest.mark.asyncio
+    @patch("app.agents.content_nodes._persist_materials")
+    @patch("app.agents.content_nodes._generate_single_content")
+    @patch("app.agents.content_nodes._validate_single_content")
+    async def test_max_iterations_flag(
+        self,
+        mock_validate: AsyncMock,
+        mock_generate: AsyncMock,
+        mock_persist: AsyncMock,
+        prioritized_gaps: list[PrioritizedGap],
+    ) -> None:
+        # All validations fail
+        mock_validate.return_value = _mock_validator_output(bloom=0.4, accuracy=0.4)
+
+        regenerated = GeneratedContent(
+            concept_id="http_fundamentals",
+            bloom_level=2,
+            sections=[ContentSection(type="explanation", title="HTTP", body="text")],
+            raw_prompt="test prompt",
+        )
+        mock_generate.return_value = (None, regenerated)
+
+        from app.graph.content_state import LearningObjective
+
+        raw_content = {
+            "http_fundamentals": GeneratedContent(
+                concept_id="http_fundamentals",
+                bloom_level=2,
+                sections=[ContentSection(type="explanation", title="HTTP", body="text")],
+                raw_prompt="test prompt",
+            ),
+        }
+
+        state: LearningMaterialState = {
+            "session_id": "sess-test",
+            "domain": "backend_engineering",
+            "prioritized_gaps": [prioritized_gaps[0]],
+            "objectives": [
+                LearningObjective(
+                    concept_id="http_fundamentals",
+                    bloom_level=2,
+                    verb="explain",
+                    objective_text="Explain HTTP fundamentals",
+                    prereq_concept_ids=[],
+                ),
+            ],
+            "raw_content": raw_content,
+        }
+
+        result = await validate_all_content(state)
+
+        materials = result["final_materials"]
+        assert materials["http_fundamentals"].iteration_count == MAX_ITERATIONS
+        assert materials["http_fundamentals"].quality_flag == "max_iterations_reached"
+
+    @pytest.mark.asyncio
+    @patch("app.agents.content_nodes._persist_materials")
+    @patch("app.agents.content_nodes._generate_single_content")
+    @patch("app.agents.content_nodes._validate_single_content")
+    async def test_critique_propagation(
+        self,
+        mock_validate: AsyncMock,
+        mock_generate: AsyncMock,
+        mock_persist: AsyncMock,
+        prioritized_gaps: list[PrioritizedGap],
+    ) -> None:
+        # First validation fails with critique, second passes
+        mock_validate.side_effect = [
+            BloomValidatorOutput(
+                bloom_alignment=0.5,
+                accuracy=0.5,
+                clarity=0.5,
+                evidence_alignment=0.5,
+                critique="Material only covers Remember level, needs Apply-level exercises.",
+            ),
+            _mock_validator_output(bloom=0.9, accuracy=0.9),
+        ]
+
+        regenerated = GeneratedContent(
+            concept_id="http_fundamentals",
+            bloom_level=2,
+            sections=[ContentSection(type="explanation", title="Better HTTP", body="improved")],
+            raw_prompt="test prompt v2",
+        )
+        mock_generate.return_value = (None, regenerated)
+
+        from app.graph.content_state import LearningObjective
+
+        raw_content = {
+            "http_fundamentals": GeneratedContent(
+                concept_id="http_fundamentals",
+                bloom_level=2,
+                sections=[ContentSection(type="explanation", title="HTTP", body="text")],
+                raw_prompt="test prompt",
+            ),
+        }
+
+        state: LearningMaterialState = {
+            "session_id": "sess-test",
+            "domain": "backend_engineering",
+            "prioritized_gaps": [prioritized_gaps[0]],
+            "objectives": [
+                LearningObjective(
+                    concept_id="http_fundamentals",
+                    bloom_level=2,
+                    verb="explain",
+                    objective_text="Explain HTTP fundamentals",
+                    prereq_concept_ids=[],
+                ),
+            ],
+            "raw_content": raw_content,
+        }
+
+        await validate_all_content(state)
+
+        # Verify critique was passed to regeneration
+        mock_generate.assert_called_once()
+        call_kwargs = mock_generate.call_args
+        assert "Material only covers Remember level" in call_kwargs[1]["critique"]

--- a/backend/tests/test_content_pipeline.py
+++ b/backend/tests/test_content_pipeline.py
@@ -1,0 +1,187 @@
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from app.agents.schemas import BloomValidatorOutput, ContentGeneratorOutput, ContentSectionOutput
+from app.graph.content_pipeline import build_content_graph
+
+
+class TestContentPipelineGraph:
+    """Test the content pipeline graph structure."""
+
+    def test_graph_builds_successfully(self) -> None:
+        graph = build_content_graph()
+        assert graph is not None
+
+    def test_graph_has_all_nodes(self) -> None:
+        graph = build_content_graph()
+        node_names = set(graph.nodes.keys())
+        expected = {
+            "input_reader",
+            "gap_prioritizer",
+            "objective_generator",
+            "generate_all_content",
+            "validate_all_content",
+        }
+        assert expected.issubset(node_names)
+
+
+class TestContentPipelineIntegration:
+    """Integration tests that run the full pipeline with mocked LLM calls."""
+
+    @pytest.mark.asyncio
+    @patch("app.agents.content_nodes.get_db")
+    @patch("app.agents.content_nodes._persist_materials")
+    @patch("app.agents.content_nodes.ainvoke_structured")
+    async def test_full_pipeline_happy_path(
+        self,
+        mock_ainvoke: AsyncMock,
+        mock_persist: AsyncMock,
+        mock_get_db: AsyncMock,
+        setup_db,
+    ) -> None:
+        from langgraph.checkpoint.memory import MemorySaver
+
+        from tests.conftest import _override_get_db, _TestSessionFactory, seed_result, seed_session
+
+        mock_get_db.side_effect = _override_get_db
+
+        # Seed test data
+        async with _TestSessionFactory() as db:
+            await seed_session(db, "sess-pipe", "thread-pipe", "completed")
+            await seed_result(
+                db,
+                "sess-pipe",
+                gap_nodes=[
+                    {
+                        "concept": "http_fundamentals",
+                        "confidence": 0.3,
+                        "bloom_level": "remember",
+                        "prerequisites": [],
+                        "evidence": ["Partial understanding"],
+                    },
+                ],
+            )
+
+        # Mock LLM: first call is content generation, second is validation
+        content_output = ContentGeneratorOutput(
+            sections=[
+                ContentSectionOutput(
+                    type="explanation",
+                    title="Understanding HTTP",
+                    body="HTTP is a protocol for web communication...",
+                ),
+                ContentSectionOutput(
+                    type="quiz",
+                    title="HTTP Quiz",
+                    body="What is HTTP?",
+                    answer="HyperText Transfer Protocol",
+                ),
+            ]
+        )
+        validator_output = BloomValidatorOutput(
+            bloom_alignment=0.9,
+            accuracy=0.95,
+            clarity=0.9,
+            evidence_alignment=0.85,
+            critique="",
+        )
+
+        # ainvoke_structured is called twice per gap: once for generation, once for validation
+        mock_ainvoke.side_effect = [content_output, validator_output]
+
+        # Build and run graph
+        from app.graph.content_pipeline import compile_content_graph
+
+        checkpointer = MemorySaver()
+        graph = compile_content_graph(checkpointer)
+
+        config = {"configurable": {"thread_id": "test-content-pipe"}}
+        initial_state = {"session_id": "sess-pipe", "domain": "backend_engineering"}
+
+        result = await graph.ainvoke(initial_state, config)
+
+        assert "final_materials" in result
+        assert "http_fundamentals" in result["final_materials"]
+        mat = result["final_materials"]["http_fundamentals"]
+        assert mat.bloom_score >= 0.75
+        assert mat.quality_score >= 0.70
+        assert mat.iteration_count == 1
+        assert mat.quality_flag is None
+
+    @pytest.mark.asyncio
+    @patch("app.agents.content_nodes.get_db")
+    @patch("app.agents.content_nodes._persist_materials")
+    @patch("app.agents.content_nodes.ainvoke_structured")
+    async def test_pipeline_with_retry(
+        self,
+        mock_ainvoke: AsyncMock,
+        mock_persist: AsyncMock,
+        mock_get_db: AsyncMock,
+        setup_db,
+    ) -> None:
+        from langgraph.checkpoint.memory import MemorySaver
+
+        from tests.conftest import _override_get_db, _TestSessionFactory, seed_result, seed_session
+
+        mock_get_db.side_effect = _override_get_db
+
+        async with _TestSessionFactory() as db:
+            await seed_session(db, "sess-retry", "thread-retry", "completed")
+            await seed_result(
+                db,
+                "sess-retry",
+                gap_nodes=[
+                    {
+                        "concept": "http_fundamentals",
+                        "confidence": 0.3,
+                        "bloom_level": "remember",
+                        "prerequisites": [],
+                        "evidence": ["Partial understanding"],
+                    },
+                ],
+            )
+
+        content_output = ContentGeneratorOutput(
+            sections=[
+                ContentSectionOutput(type="explanation", title="HTTP", body="HTTP explanation..."),
+            ]
+        )
+        failing_validation = BloomValidatorOutput(
+            bloom_alignment=0.4,
+            accuracy=0.5,
+            clarity=0.5,
+            evidence_alignment=0.5,
+            critique="Needs more depth at Understand level.",
+        )
+        passing_validation = BloomValidatorOutput(
+            bloom_alignment=0.9,
+            accuracy=0.9,
+            clarity=0.9,
+            evidence_alignment=0.9,
+            critique="",
+        )
+
+        # Call sequence: generate, validate(fail), regenerate, validate(pass)
+        mock_ainvoke.side_effect = [
+            content_output,
+            failing_validation,
+            content_output,
+            passing_validation,
+        ]
+
+        from app.graph.content_pipeline import compile_content_graph
+
+        checkpointer = MemorySaver()
+        graph = compile_content_graph(checkpointer)
+
+        config = {"configurable": {"thread_id": "test-retry-pipe"}}
+        initial_state = {"session_id": "sess-retry", "domain": "backend_engineering"}
+
+        result = await graph.ainvoke(initial_state, config)
+
+        mat = result["final_materials"]["http_fundamentals"]
+        assert mat.iteration_count == 2
+        assert mat.quality_flag is None

--- a/backend/tests/test_materials_route.py
+++ b/backend/tests/test_materials_route.py
@@ -1,0 +1,123 @@
+from __future__ import annotations
+
+import pytest
+
+# ── Test app with materials router ──────────────────────────────────────
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+
+from app.db import MaterialResult, get_db
+from app.deps import get_current_user, get_user_api_key
+from app.routes.materials import router as materials_router
+from tests.conftest import (
+    _override_get_current_user,
+    _override_get_db,
+    _override_get_user_api_key,
+    _TestSessionFactory,
+    seed_session,
+)
+
+_materials_test_app = FastAPI()
+_materials_test_app.include_router(materials_router, prefix="/api")
+_materials_test_app.dependency_overrides[get_db] = _override_get_db
+_materials_test_app.dependency_overrides[get_current_user] = _override_get_current_user
+_materials_test_app.dependency_overrides[get_user_api_key] = _override_get_user_api_key
+
+
+# ── Seed helpers ────────────────────────────────────────────────────────
+
+
+async def seed_material(
+    session_id: str = "sess-001",
+    concept_id: str = "http_fundamentals",
+    domain: str = "backend_engineering",
+    bloom_score: float = 0.9,
+    quality_score: float = 0.85,
+    quality_flag: str | None = None,
+) -> None:
+    async with _TestSessionFactory() as db:
+        db.add(
+            MaterialResult(
+                session_id=session_id,
+                concept_id=concept_id,
+                domain=domain,
+                bloom_score=bloom_score,
+                quality_score=quality_score,
+                iteration_count=1,
+                quality_flag=quality_flag,
+                material={
+                    "concept_id": concept_id,
+                    "target_bloom": 2,
+                    "sections": [{"type": "explanation", "title": "Test", "body": "Test content"}],
+                    "bloom_score": bloom_score,
+                    "quality_score": quality_score,
+                    "iteration_count": 1,
+                },
+            )
+        )
+        await db.commit()
+
+
+class TestMaterialsRoute:
+    @pytest.mark.asyncio
+    async def test_get_materials_success(self, setup_db) -> None:
+        async with _TestSessionFactory() as db:
+            await seed_session(db, "sess-mat", "thread-mat", "completed")
+
+        await seed_material(session_id="sess-mat")
+
+        async with AsyncClient(
+            transport=ASGITransport(app=_materials_test_app), base_url="http://test"
+        ) as client:
+            response = await client.get("/api/materials/sess-mat")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["sessionId"] == "sess-mat"
+        assert len(data["materials"]) == 1
+        assert data["materials"][0]["conceptId"] == "http_fundamentals"
+        assert data["materials"][0]["bloomScore"] == 0.9
+
+    @pytest.mark.asyncio
+    async def test_get_materials_with_quality_flag(self, setup_db) -> None:
+        async with _TestSessionFactory() as db:
+            await seed_session(db, "sess-flag", "thread-flag", "completed")
+
+        await seed_material(
+            session_id="sess-flag",
+            bloom_score=0.5,
+            quality_flag="max_iterations_reached",
+        )
+
+        async with AsyncClient(
+            transport=ASGITransport(app=_materials_test_app), base_url="http://test"
+        ) as client:
+            response = await client.get("/api/materials/sess-flag")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["materials"][0]["qualityFlag"] == "max_iterations_reached"
+
+    @pytest.mark.asyncio
+    async def test_get_materials_session_not_found(self, setup_db) -> None:
+        async with AsyncClient(
+            transport=ASGITransport(app=_materials_test_app), base_url="http://test"
+        ) as client:
+            response = await client.get("/api/materials/nonexistent")
+
+        assert response.status_code == 404
+
+    @pytest.mark.asyncio
+    async def test_get_materials_empty_in_progress(self, setup_db) -> None:
+        async with _TestSessionFactory() as db:
+            await seed_session(db, "sess-prog", "thread-prog", "completed")
+
+        async with AsyncClient(
+            transport=ASGITransport(app=_materials_test_app), base_url="http://test"
+        ) as client:
+            response = await client.get("/api/materials/sess-prog")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["sessionId"] == "sess-prog"
+        assert data["materials"] == []

--- a/backend/tests/test_taxonomy.py
+++ b/backend/tests/test_taxonomy.py
@@ -1,0 +1,142 @@
+from __future__ import annotations
+
+import pytest
+
+from app.knowledge_base.taxonomy import (
+    BLOOM_INT,
+    IRT_TIER_FALLBACK,
+    TaxonomyIndex,
+    clear_taxonomy_cache,
+)
+
+
+@pytest.fixture(autouse=True)
+def _clear_cache():
+    clear_taxonomy_cache()
+    yield
+    clear_taxonomy_cache()
+
+
+@pytest.fixture
+def taxonomy() -> TaxonomyIndex:
+    return TaxonomyIndex("backend_engineering")
+
+
+class TestBloomTargetInt:
+    def test_valid_concept(self, taxonomy: TaxonomyIndex) -> None:
+        # http_fundamentals has bloom_target "understand" → 2
+        assert taxonomy.bloom_target_int("http_fundamentals") == BLOOM_INT["understand"]
+
+    def test_apply_level_concept(self, taxonomy: TaxonomyIndex) -> None:
+        # rest_api_basics has bloom_target "apply" → 3
+        assert taxonomy.bloom_target_int("rest_api_basics") == BLOOM_INT["apply"]
+
+    def test_missing_concept_raises(self, taxonomy: TaxonomyIndex) -> None:
+        with pytest.raises(KeyError, match="not found in taxonomy"):
+            taxonomy.bloom_target_int("nonexistent_concept")
+
+
+class TestGapSeverity:
+    def test_normal_gap(self, taxonomy: TaxonomyIndex) -> None:
+        # http_fundamentals has target_confidence 0.7
+        severity = taxonomy.gap_severity("http_fundamentals", 0.3)
+        assert severity == pytest.approx(0.4)
+
+    def test_zero_gap(self, taxonomy: TaxonomyIndex) -> None:
+        severity = taxonomy.gap_severity("http_fundamentals", 0.7)
+        assert severity == pytest.approx(0.0)
+
+    def test_negative_clamps_to_zero(self, taxonomy: TaxonomyIndex) -> None:
+        severity = taxonomy.gap_severity("http_fundamentals", 0.9)
+        assert severity == 0.0
+
+    def test_full_gap(self, taxonomy: TaxonomyIndex) -> None:
+        severity = taxonomy.gap_severity("http_fundamentals", 0.0)
+        assert severity == pytest.approx(0.7)
+
+
+class TestIrtWeight:
+    def test_with_db_weight(self, taxonomy: TaxonomyIndex) -> None:
+        weight = taxonomy.irt_weight("http_fundamentals", db_weight=2.5)
+        assert weight == 2.5
+
+    def test_fallback_junior_tier(self, taxonomy: TaxonomyIndex) -> None:
+        # http_fundamentals is junior level
+        weight = taxonomy.irt_weight("http_fundamentals")
+        assert weight == IRT_TIER_FALLBACK["junior"]
+
+    def test_missing_concept_raises(self, taxonomy: TaxonomyIndex) -> None:
+        with pytest.raises(KeyError, match="not found in taxonomy"):
+            taxonomy.irt_weight("nonexistent_concept")
+
+
+class TestPrereqs:
+    def test_with_dependencies(self, taxonomy: TaxonomyIndex) -> None:
+        prereqs = taxonomy.prereqs("rest_api_basics")
+        assert "http_fundamentals" in prereqs
+
+    def test_no_dependencies(self, taxonomy: TaxonomyIndex) -> None:
+        prereqs = taxonomy.prereqs("http_fundamentals")
+        assert prereqs == []
+
+
+class TestCltParams:
+    def test_junior_tier(self, taxonomy: TaxonomyIndex) -> None:
+        params = taxonomy.clt_params("http_fundamentals", bloom_distance=2)
+        assert params["chunk_count"] == 2  # ceil(2 * 1.0)
+        assert params["example_count"] == 2
+        assert params["scaffolding_depth"] == "medium"
+
+    def test_bloom_distance_one(self, taxonomy: TaxonomyIndex) -> None:
+        params = taxonomy.clt_params("http_fundamentals", bloom_distance=1)
+        assert params["chunk_count"] == 1  # ceil(1 * 1.0)
+
+    def test_minimum_chunk_count(self, taxonomy: TaxonomyIndex) -> None:
+        params = taxonomy.clt_params("http_fundamentals", bloom_distance=0)
+        assert params["chunk_count"] >= 1
+
+
+class TestTopologicalSort:
+    def test_linear_chain(self, taxonomy: TaxonomyIndex) -> None:
+        from app.agents.content_nodes import _topological_sort
+
+        # http_fundamentals → rest_api_basics → crud_operations
+        concept_ids = ["crud_operations", "rest_api_basics", "http_fundamentals"]
+        sorted_ids = _topological_sort(concept_ids, taxonomy)
+
+        # http_fundamentals should come before rest_api_basics, which should come before crud_operations
+        assert sorted_ids.index("http_fundamentals") < sorted_ids.index("rest_api_basics")
+        assert sorted_ids.index("rest_api_basics") < sorted_ids.index("crud_operations")
+
+    def test_no_deps(self, taxonomy: TaxonomyIndex) -> None:
+        from app.agents.content_nodes import _topological_sort
+
+        concept_ids = ["http_fundamentals", "error_handling"]
+        sorted_ids = _topological_sort(concept_ids, taxonomy)
+        assert set(sorted_ids) == {"http_fundamentals", "error_handling"}
+
+    def test_diamond_dependency(self, taxonomy: TaxonomyIndex) -> None:
+        from app.agents.content_nodes import _topological_sort
+
+        # sql_basics → database_schema_design, sql_basics → orm_basics
+        concept_ids = ["database_schema_design", "orm_basics", "sql_basics"]
+        sorted_ids = _topological_sort(concept_ids, taxonomy)
+        assert sorted_ids.index("sql_basics") < sorted_ids.index("database_schema_design")
+        assert sorted_ids.index("sql_basics") < sorted_ids.index("orm_basics")
+
+
+class TestTaxonomyIndexMisc:
+    def test_has_concept(self, taxonomy: TaxonomyIndex) -> None:
+        assert taxonomy.has("http_fundamentals") is True
+        assert taxonomy.has("nonexistent") is False
+
+    def test_domain_property(self, taxonomy: TaxonomyIndex) -> None:
+        assert taxonomy.domain == "backend_engineering"
+
+    def test_all_concept_ids_not_empty(self, taxonomy: TaxonomyIndex) -> None:
+        all_ids = taxonomy.all_concept_ids()
+        assert len(all_ids) > 0
+        assert "http_fundamentals" in all_ids
+
+    def test_level(self, taxonomy: TaxonomyIndex) -> None:
+        assert taxonomy.level("http_fundamentals") == "junior"

--- a/docs/architecture/data-models.md
+++ b/docs/architecture/data-models.md
@@ -478,9 +478,30 @@ class PlanOutput(BaseModel):
     phases: list[PlanPhaseOutput]
 ```
 
+### Content Generation
+
+```python
+class ContentSectionOutput(BaseModel):
+    type: str            # "explanation", "code_example", "analogy", "quiz"
+    title: str
+    body: str
+    code_block: str | None
+    answer: str | None
+
+class ContentGeneratorOutput(BaseModel):
+    sections: list[ContentSectionOutput]
+
+class BloomValidatorOutput(BaseModel):
+    bloom_alignment: float    # 0.0-1.0
+    accuracy: float           # 0.0-1.0
+    clarity: float            # 0.0-1.0
+    evidence_alignment: float # 0.0-1.0
+    critique: str             # Actionable feedback if any score < 0.75
+```
+
 ## Database Schema
 
-PostgreSQL database with four tables for persisting users, authentication methods, assessment sessions, and results.
+PostgreSQL database with six tables for persisting users, authentication methods, assessment sessions, results, concept configuration, and generated learning materials.
 
 **Source**: `backend/app/db.py`
 
@@ -532,6 +553,33 @@ Unique constraint: `(provider, provider_id)`
 | `learning_plan` | `JSONB` | Generated learning plan |
 | `proficiency_scores` | `JSONB` | Per-skill proficiency scores |
 | `completed_at` | `DateTime` | Completion timestamp |
+
+### `concept_config`
+
+| Column | Type | Description |
+|--------|------|-------------|
+| `concept_id` | `String` PK | Concept identifier (matches taxonomy YAML) |
+| `domain` | `String` | Knowledge domain |
+| `irt_weight` | `Float` | IRT difficulty weight (default: 1.0) |
+| `notes` | `String` NULL | Optional operator notes |
+| `updated_at` | `DateTime` | Last modification timestamp |
+
+### `material_results`
+
+| Column | Type | Description |
+|--------|------|-------------|
+| `id` | `Integer` PK | Auto-incrementing ID |
+| `session_id` | `String(36)` FK | References `assessment_sessions.session_id` |
+| `concept_id` | `String` | Concept the material addresses |
+| `domain` | `String` | Knowledge domain |
+| `bloom_score` | `Float` | Bloom alignment score from validator |
+| `quality_score` | `Float` | Composite quality score |
+| `iteration_count` | `Integer` | Number of generation iterations |
+| `quality_flag` | `String` NULL | Set if emitted without passing quality gate |
+| `material` | `JSONB` | Full generated learning material |
+| `generated_at` | `DateTime` | Creation timestamp |
+
+Unique constraint: `(session_id, concept_id)`
 
 ### Relationships
 

--- a/docs/architecture/learning-content.md
+++ b/docs/architecture/learning-content.md
@@ -2,7 +2,7 @@
 
 The learning content pipeline is a LangGraph StateGraph that automatically generates personalized learning material from assessment results. It consumes the structured output of the assessment pipeline — knowledge gaps, Bloom levels, confidence scores, and evidence — and produces validated, Bloom-aligned content for each gap.
 
-**Source**: `backend/app/graph/content_pipeline.py`, `backend/app/graph/content_state.py` *(planned)*
+**Source**: `backend/app/graph/content_pipeline.py`, `backend/app/graph/content_state.py`, `backend/app/agents/content_nodes.py`
 
 ## Pipeline Overview
 

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -56,6 +56,7 @@ graph LR
     B --> C[Assessment Loop]
     C --> D[Gap Analysis]
     D --> E[Learning Plan]
+    E --> F[Content Generation]
 ```
 
 1. **Onboarding** — User selects a role (primary path) or browses and selects skills manually. Skills are mapped to a knowledge base domain.
@@ -63,6 +64,7 @@ graph LR
 3. **Assessment Loop** — Adaptive question-answer cycle builds a detailed knowledge graph through Bloom taxonomy levels.
 4. **Gap Analysis** — Current knowledge graph is diffed against the target graph. Gaps are topologically sorted by prerequisites.
 5. **Learning Plan** — Claude generates a phased plan from the identified gaps with concrete resources.
+6. **Content Generation** — A background LangGraph pipeline generates Bloom-validated learning material for each knowledge gap, with quality gating and retry loops.
 
 ### Session Management
 
@@ -128,7 +130,7 @@ OpenLearning/
 │   │   ├── config.py            # Settings (API key, CORS origins, GitHub OAuth, JWT, encryption)
 │   │   ├── db.py                # SQLAlchemy models, async engine, session factory
 │   │   ├── models/              # Pydantic models (API request/response contracts)
-│   │   ├── routes/              # API endpoints (health, skills, assessment, gap_analysis, learning_plan, roles, auth) + export helpers
+│   │   ├── routes/              # API endpoints (health, skills, assessment, gap_analysis, learning_plan, materials, roles, auth) + export helpers
 │   │   ├── deps.py              # Auth dependencies (JWT cookie extraction, user validation, API key injection)
 │   │   ├── crypto.py            # Fernet encryption/decryption for API keys
 │   │   ├── services/            # AI service layer (structured LLM output, retry, JSON parsing, session cleanup)

--- a/docs/guides/api-reference.md
+++ b/docs/guides/api-reference.md
@@ -637,6 +637,56 @@ Generate a personalized learning plan from gap analysis.
 {"detail": "No API key configured. Please add your Anthropic API key in Settings."}
 ```
 
+---
+
+### GET `/api/materials/{session_id}`
+
+> **Requires authentication.** Returns 401 without a valid JWT cookie.
+
+Retrieve generated learning materials for a completed assessment session. Materials are generated automatically in the background when an assessment completes.
+
+**Path parameter**: `session_id` — the assessment session UUID
+
+**Response** (200): `MaterialsResponse`
+
+```json
+{
+  "sessionId": "550e8400-e29b-41d4-a716-446655440000",
+  "materials": [
+    {
+      "conceptId": "http_fundamentals",
+      "domain": "backend_engineering",
+      "bloomScore": 0.91,
+      "qualityScore": 0.88,
+      "iterationCount": 1,
+      "qualityFlag": null,
+      "material": {
+        "concept_id": "http_fundamentals",
+        "target_bloom": 2,
+        "sections": [
+          {"type": "explanation", "title": "What HTTP does", "body": "..."},
+          {"type": "code_example", "title": "HTTP Request", "body": "...", "codeBlock": "..."},
+          {"type": "quiz", "title": "Check understanding", "body": "...", "answer": "..."}
+        ]
+      },
+      "generatedAt": "2026-03-23T12:00:00Z"
+    }
+  ]
+}
+```
+
+An empty `materials` list indicates the pipeline is still running.
+
+**Response** (404 — session not found):
+
+```json
+{"detail": "Session not found"}
+```
+
+**Source**: `backend/app/routes/materials.py`
+
+---
+
 ## Anthropic Error Responses
 
 When the backend encounters an Anthropic SDK exception, it maps it to a structured HTTP error:


### PR DESCRIPTION

## Summary

Add a LangGraph-based pipeline that consumes AssessmentResult records and generates Bloom-validated, personalized learning material for each knowledge gap. The pipeline runs as a background task when an assessment completes.

Key components:
- 5-node StateGraph: input_reader → gap_prioritizer → objective_generator → generate_all_content → validate_all_content
- TaxonomyIndex class wrapping KB YAML with CLT/IRT/Bloom accessors
- Quality gate with retry loop (max 3 iterations, critique feedback)
- GET /api/materials/{session_id} endpoint with ownership check
- ConceptConfig and MaterialResult ORM models
- 36 tests covering taxonomy, nodes, pipeline integration, and routes


## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Knowledge base contribution
- [x] Documentation
- [ ] Infrastructure / CI
- [x] Refactoring

## Related Issues

Closes #85 

## Checklist

- [x] I have run `make check` and all checks pass
- [x] I have added tests for new functionality
- [x] I have updated documentation if needed
- [x] My changes do not introduce new warnings
