### PR TITLE
fix: add defense-in-depth origin validation for OAuth redirect

### DIFF
--- a/backend/app/routes/auth.py
+++ b/backend/app/routes/auth.py
@@ -247,7 +247,12 @@ async def github_callback(
 
     # Create JWT and set cookie
     token = _create_jwt(user, settings.jwt_secret_key)
-    response = RedirectResponse(url=f"{settings.frontend_url}{redirect_path}", status_code=302)
+    final_url = f"{settings.frontend_url}{redirect_path}"
+    parsed_final = urlparse(final_url)
+    parsed_base = urlparse(settings.frontend_url)
+    if parsed_final.netloc != parsed_base.netloc:
+        final_url = settings.frontend_url
+    response = RedirectResponse(url=final_url, status_code=302)
     _set_auth_cookie(response, token, settings.frontend_url)
     return response
 


### PR DESCRIPTION


## Summary

Resolves CodeQL alert #7 (py/url-redirection). After constructing the OAuth callback redirect URL, verify the parsed origin matches the configured frontend URL to prevent open redirect via URL parsing edge cases.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Knowledge base contribution
- [ ] Documentation
- [ ] Infrastructure / CI
- [ ] Refactoring

## Related Issues

Closes #

## Checklist

- [ ] I have run `make check` and all checks pass
- [ ] I have added tests for new functionality
- [ ] I have updated documentation if needed
- [ ] My changes do not introduce new warnings
