### PR TITLE
fix: extract readable message from FastAPI validation error arrays

### DIFF
--- a/frontend/src/app/login/page.test.tsx
+++ b/frontend/src/app/login/page.test.tsx
@@ -146,6 +146,24 @@ describe("LoginPage", () => {
     });
   });
 
+  it("shows readable message from validation error, not [object Object]", async () => {
+    const user = userEvent.setup();
+    const err = new Error("Invalid email format; Too short");
+    err.name = "ApiError";
+    vi.mocked(api.authLogin).mockRejectedValue(err);
+    render(<LoginPage />);
+    await user.type(screen.getByPlaceholderText("Email"), "test@example.com");
+    await user.type(screen.getByPlaceholderText("Password"), "short");
+    await user.click(screen.getByRole("button", { name: "Sign In" }));
+
+    await waitFor(() => {
+      expect(
+        screen.getByText("Invalid email format; Too short")
+      ).toBeInTheDocument();
+      expect(screen.queryByText("[object Object]")).not.toBeInTheDocument();
+    });
+  });
+
   it.each([
     ["https://evil.com", "/dashboard"],
     ["//evil.com", "/dashboard"],

--- a/frontend/src/lib/api.test.ts
+++ b/frontend/src/lib/api.test.ts
@@ -11,7 +11,7 @@ vi.mock("@/lib/generated/api-client/client.gen", () => ({
   client: { setConfig: vi.fn() },
 }));
 
-import { unwrap, api, ApiError, parseRetryAfter } from "./api";
+import { unwrap, api, ApiError, parseRetryAfter, extractDetail } from "./api";
 import {
   getSkillsApiSkillsGet,
   listUserAssessmentsApiUserAssessmentsGet,
@@ -110,6 +110,54 @@ describe("unwrap", () => {
       expect(e).toBeInstanceOf(ApiError);
       expect((e as ApiError).status).toBe(500);
     }
+  });
+
+  it("extracts messages from FastAPI validation error array", () => {
+    const mockResponse = { status: 422, headers: new Headers() } as Response;
+    const detail = [
+      { type: "value_error", loc: ["body", "email"], msg: "Invalid email format", input: "bad" },
+      { type: "value_error", loc: ["body", "password"], msg: "Too short", input: "x" },
+    ];
+    expect(() =>
+      unwrap({ error: { detail }, response: mockResponse })
+    ).toThrow("Invalid email format; Too short");
+  });
+
+  it("falls back when detail is an unrecognized type", () => {
+    const mockResponse = { status: 500, headers: new Headers() } as Response;
+    expect(() =>
+      unwrap({ error: { detail: 42 }, response: mockResponse })
+    ).toThrow("Request failed");
+  });
+});
+
+describe("extractDetail", () => {
+  it("returns string detail as-is", () => {
+    expect(extractDetail("Not found", "fallback")).toBe("Not found");
+  });
+
+  it("joins msg fields from validation error array", () => {
+    const detail = [
+      { msg: "field required" },
+      { msg: "invalid format" },
+    ];
+    expect(extractDetail(detail, "fallback")).toBe("field required; invalid format");
+  });
+
+  it("returns fallback for empty array", () => {
+    expect(extractDetail([], "fallback")).toBe("fallback");
+  });
+
+  it("returns fallback for array without msg fields", () => {
+    expect(extractDetail([{ code: 123 }], "fallback")).toBe("fallback");
+  });
+
+  it("returns fallback for null", () => {
+    expect(extractDetail(null, "fallback")).toBe("fallback");
+  });
+
+  it("returns fallback for undefined", () => {
+    expect(extractDetail(undefined, "fallback")).toBe("fallback");
   });
 });
 

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -53,6 +53,24 @@ export class ApiError extends Error {
   }
 }
 
+/**
+ * Normalize FastAPI's `detail` field into a readable string.
+ * Handles: string, array of {msg: string} (validation errors), or fallback.
+ */
+export function extractDetail(
+  detail: unknown,
+  fallback: string
+): string {
+  if (typeof detail === "string") return detail;
+  if (Array.isArray(detail)) {
+    const messages = detail
+      .map((item) => (typeof item === "object" && item !== null && "msg" in item ? item.msg : null))
+      .filter((msg): msg is string => typeof msg === "string");
+    if (messages.length > 0) return messages.join("; ");
+  }
+  return fallback;
+}
+
 async function throwFromResponse(
   res: Response,
   fallback: string
@@ -60,7 +78,7 @@ async function throwFromResponse(
   const err = await res.json().catch(() => ({ detail: fallback }));
   const retryAfter = res.headers?.get("Retry-After");
   throw new ApiError(
-    err.detail ?? fallback,
+    extractDetail(err.detail, fallback),
     res.status,
     parseRetryAfter(retryAfter)
   );
@@ -72,11 +90,11 @@ export function unwrap<T>(result: {
   response?: Response;
 }): T {
   if (result.error !== undefined) {
-    const err = result.error as { detail?: string };
+    const err = result.error as { detail?: unknown };
     const status = result.response?.status ?? 500;
     const retryAfter = result.response?.headers?.get("Retry-After");
     throw new ApiError(
-      err?.detail ?? "Request failed",
+      extractDetail(err?.detail, "Request failed"),
       status,
       parseRetryAfter(retryAfter)
     );


### PR DESCRIPTION



## Summary

The unwrap() and throwFromResponse() functions passed the raw `detail` field to ApiError without checking its type. FastAPI returns `detail` as an array of objects for 422 validation errors, which rendered as "[object Object]" on the login page. The new extractDetail() helper normalizes string, array, and unknown detail formats into readable messages.


## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Knowledge base contribution
- [ ] Documentation
- [ ] Infrastructure / CI
- [ ] Refactoring

## Related Issues

Closes #98 

## Checklist

- [x] I have run `make check` and all checks pass
- [x] I have added tests for new functionality
- [x] I have updated documentation if needed
- [x] My changes do not introduce new warnings
