### PR TITLE
feat: add navigation between gap analysis and learning plan views

### DIFF
--- a/frontend/src/app/assess/page.tsx
+++ b/frontend/src/app/assess/page.tsx
@@ -168,7 +168,7 @@ function AssessPageContent() {
   if (!resumeSessionId && selectedSkillIds.length === 0) return null;
 
   return (
-    <PageShell currentStep={1} noPadding autoPromptApiKey>
+    <PageShell currentStep={1} noPadding autoPromptApiKey sessionId={sessionId || resumeSessionId}>
       <div className="flex h-[calc(100dvh - var(--header-h))] flex-col">
         {/* Header */}
         <div className="border-b border-border px-4 py-3 sm:px-6">

--- a/frontend/src/app/gap-analysis/page.tsx
+++ b/frontend/src/app/gap-analysis/page.tsx
@@ -12,7 +12,7 @@ import { useAuthStore } from "@/lib/auth-store";
 import { useAuth } from "@/hooks/useAuth";
 import { useSessionReport } from "@/hooks/useSessionReport";
 import { ApiErrorDisplay } from "@/components/error/api-error-display";
-import { ArrowRight, Loader2 } from "lucide-react";
+import { ArrowRight, Loader2, Eye } from "lucide-react";
 
 export default function GapAnalysisPage() {
   return (
@@ -57,7 +57,7 @@ function GapAnalysisPageContent() {
 
   if (loading) {
     return (
-      <PageShell currentStep={2}>
+      <PageShell currentStep={2} sessionId={sessionId}>
         <div className="flex flex-col items-center justify-center py-32 gap-4">
           <Loader2 className="h-8 w-8 animate-spin text-cyan" />
           <p className="text-muted-foreground font-mono text-sm">
@@ -81,7 +81,7 @@ function GapAnalysisPageContent() {
 
   if (error) {
     return (
-      <PageShell currentStep={2}>
+      <PageShell currentStep={2} sessionId={sessionId}>
         <div className="flex flex-col items-center justify-center py-32 gap-4">
           <ApiErrorDisplay error={error} onRetry={refetch} />
         </div>
@@ -94,7 +94,7 @@ function GapAnalysisPageContent() {
   const { gapAnalysis } = report;
 
   return (
-    <PageShell currentStep={2}>
+    <PageShell currentStep={2} sessionId={sessionId}>
       <div className="space-y-8">
         <div className="grid gap-8 lg:grid-cols-2">
           {/* Left: Chart + Readiness */}
@@ -120,7 +120,7 @@ function GapAnalysisPageContent() {
         </div>
 
         {/* CTA */}
-        <div className="flex justify-center pb-8">
+        <div className="flex flex-col items-center gap-3 pb-8 sm:flex-row sm:justify-center">
           <Button
             onClick={handleContinue}
             size="lg"
@@ -129,6 +129,17 @@ function GapAnalysisPageContent() {
             Generate Learning Plan
             <ArrowRight className="h-4 w-4" />
           </Button>
+          {report.learningPlan && report.learningPlan.phases.length > 0 && (
+            <Button
+              onClick={handleContinue}
+              size="lg"
+              variant="outline"
+              className="gap-2 border-border"
+            >
+              <Eye className="h-4 w-4" />
+              View Learning Plan
+            </Button>
+          )}
         </div>
       </div>
     </PageShell>

--- a/frontend/src/app/learning-plan/page.tsx
+++ b/frontend/src/app/learning-plan/page.tsx
@@ -12,7 +12,7 @@ import { useAuth } from "@/hooks/useAuth";
 import { useSessionReport } from "@/hooks/useSessionReport";
 import { ApiErrorDisplay } from "@/components/error/api-error-display";
 import { cn } from "@/lib/utils";
-import { Loader2, Copy, RotateCcw, Check, FileDown } from "lucide-react";
+import { Loader2, Copy, RotateCcw, Check, FileDown, ArrowLeft } from "lucide-react";
 
 export default function LearningPlanPage() {
   return (
@@ -61,6 +61,10 @@ function LearningPlanPageContent() {
     setTimeout(() => setCopied(false), 2000);
   };
 
+  const handleBackToGaps = () => {
+    router.push(`/gap-analysis${sessionId ? `?session=${sessionId}` : ""}`);
+  };
+
   const handleStartOver = () => {
     reset();
     router.push("/");
@@ -71,7 +75,7 @@ function LearningPlanPageContent() {
 
   if (loading) {
     return (
-      <PageShell currentStep={3}>
+      <PageShell currentStep={3} sessionId={sessionId}>
         <div className="flex flex-col items-center justify-center py-32 gap-4">
           <Loader2 className="h-8 w-8 animate-spin text-cyan" />
           <p className="text-muted-foreground font-mono text-sm">
@@ -95,7 +99,7 @@ function LearningPlanPageContent() {
 
   if (error) {
     return (
-      <PageShell currentStep={3}>
+      <PageShell currentStep={3} sessionId={sessionId}>
         <div className="flex flex-col items-center justify-center py-32 gap-4">
           <ApiErrorDisplay error={error} onRetry={refetch} />
         </div>
@@ -108,7 +112,7 @@ function LearningPlanPageContent() {
   const { learningPlan } = report;
 
   return (
-    <PageShell currentStep={3}>
+    <PageShell currentStep={3} sessionId={sessionId}>
       <div className="grid gap-8 lg:grid-cols-[260px,1fr]">
         {/* Left sidebar */}
         <aside className="space-y-6">
@@ -148,6 +152,14 @@ function LearningPlanPageContent() {
 
       {/* Footer */}
       <div className="mt-12 flex flex-col items-center gap-4 border-t border-border pt-8 pb-8 sm:flex-row sm:justify-center">
+        <Button
+          onClick={handleBackToGaps}
+          variant="outline"
+          className="gap-2 border-border"
+        >
+          <ArrowLeft className="h-4 w-4" />
+          Back to Gap Analysis
+        </Button>
         <Button
           onClick={handleCopyPlan}
           variant="outline"

--- a/frontend/src/components/layout/PageShell.tsx
+++ b/frontend/src/components/layout/PageShell.tsx
@@ -24,6 +24,7 @@ interface PageShellProps {
   noPadding?: boolean;
   isDemo?: boolean;
   steps?: StepDefinition[];
+  sessionId?: string | null;
   autoPromptApiKey?: boolean;
   onApiKeySet?: () => void;
 }
@@ -35,6 +36,7 @@ export function PageShell({
   noPadding = false,
   isDemo = false,
   steps,
+  sessionId,
   autoPromptApiKey = false,
   onApiKeySet,
 }: PageShellProps) {
@@ -83,7 +85,7 @@ export function PageShell({
               </Link>
             )}
             {currentStep !== undefined && (
-              <StepProgress currentStep={currentStep} steps={steps} />
+              <StepProgress currentStep={currentStep} steps={steps} sessionId={sessionId} />
             )}
             {!isDemo && (
               <div className="flex items-center gap-2">

--- a/frontend/src/components/layout/StepProgress.test.tsx
+++ b/frontend/src/components/layout/StepProgress.test.tsx
@@ -1,0 +1,48 @@
+import { render, screen } from "@testing-library/react";
+import { StepProgress } from "./StepProgress";
+
+describe("StepProgress", () => {
+  it("renders all step labels", () => {
+    render(<StepProgress currentStep={0} />);
+    expect(screen.getByText("Skills")).toBeInTheDocument();
+    expect(screen.getByText("Assess")).toBeInTheDocument();
+    expect(screen.getByText("Gaps")).toBeInTheDocument();
+    expect(screen.getByText("Plan")).toBeInTheDocument();
+  });
+
+  it("makes completed steps clickable links", () => {
+    render(<StepProgress currentStep={2} sessionId="session-123" />);
+    // Steps 0 (Skills) and 1 (Assess) are completed — should be links
+    const skillsLink = screen.getByText("Skills").closest("a");
+    expect(skillsLink).toBeInTheDocument();
+    expect(skillsLink).toHaveAttribute("href", "/");
+
+    const assessLink = screen.getByText("Assess").closest("a");
+    expect(assessLink).toBeInTheDocument();
+    expect(assessLink).toHaveAttribute("href", "/assess?session=session-123");
+  });
+
+  it("does not make the current step a link", () => {
+    render(<StepProgress currentStep={2} sessionId="session-123" />);
+    const gapsLabel = screen.getByText("Gaps");
+    expect(gapsLabel.closest("a")).not.toBeInTheDocument();
+  });
+
+  it("does not make future steps clickable", () => {
+    render(<StepProgress currentStep={2} sessionId="session-123" />);
+    const planLabel = screen.getByText("Plan");
+    expect(planLabel.closest("a")).not.toBeInTheDocument();
+  });
+
+  it("builds hrefs without session param when sessionId is not provided", () => {
+    render(<StepProgress currentStep={3} />);
+    const gapsLink = screen.getByText("Gaps").closest("a");
+    expect(gapsLink).toHaveAttribute("href", "/gap-analysis");
+  });
+
+  it("always links Skills step to / without session param", () => {
+    render(<StepProgress currentStep={3} sessionId="session-456" />);
+    const skillsLink = screen.getByText("Skills").closest("a");
+    expect(skillsLink).toHaveAttribute("href", "/");
+  });
+});

--- a/frontend/src/components/layout/StepProgress.tsx
+++ b/frontend/src/components/layout/StepProgress.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import Link from "next/link";
 import { cn } from "@/lib/utils";
 import { motion } from "motion/react";
 
@@ -18,55 +19,81 @@ const defaultSteps: StepDefinition[] = [
 interface StepProgressProps {
   currentStep: number;
   steps?: StepDefinition[];
+  sessionId?: string | null;
 }
 
-export function StepProgress({ currentStep, steps = defaultSteps }: StepProgressProps) {
+export function StepProgress({ currentStep, steps = defaultSteps, sessionId }: StepProgressProps) {
+  function buildHref(path: string): string {
+    if (!sessionId || path === "/") return path;
+    return `${path}?session=${sessionId}`;
+  }
+
   return (
     <div className="flex items-center gap-1 sm:gap-2">
-      {steps.map((step, index) => (
-        <div key={step.label} className="flex items-center gap-1 sm:gap-2">
-          <div className="flex items-center gap-1 sm:gap-2">
+      {steps.map((step, index) => {
+        const isCompleted = index < currentStep;
+        const isCurrent = index === currentStep;
+        const isClickable = isCompleted && !isCurrent;
+
+        const indicator = (
+          <>
             <motion.div
               className={cn(
                 "flex h-6 w-6 sm:h-8 sm:w-8 items-center justify-center rounded-full text-[10px] sm:text-xs font-mono font-semibold transition-colors",
-                index < currentStep
+                isCompleted
                   ? "bg-cyan text-background"
-                  : index === currentStep
+                  : isCurrent
                     ? "border-2 border-cyan text-cyan"
-                    : "border border-border text-muted-foreground"
+                    : "border border-border text-muted-foreground",
+                isClickable && "hover:bg-cyan/80 cursor-pointer"
               )}
               initial={{ scale: 0.8, opacity: 0 }}
               animate={{ scale: 1, opacity: 1 }}
               transition={{ delay: index * 0.1 }}
             >
-              {index < currentStep ? "✓" : index + 1}
+              {isCompleted ? "✓" : index + 1}
             </motion.div>
             <span
               className={cn(
                 "hidden text-sm font-medium sm:block",
                 index <= currentStep
                   ? "text-foreground"
-                  : "text-muted-foreground"
+                  : "text-muted-foreground",
+                isClickable && "hover:text-cyan cursor-pointer"
               )}
             >
               {step.label}
             </span>
+          </>
+        );
+
+        return (
+          <div key={step.label} className="flex items-center gap-1 sm:gap-2">
+            {isClickable ? (
+              <Link href={buildHref(step.path)} className="flex items-center gap-1 sm:gap-2">
+                {indicator}
+              </Link>
+            ) : (
+              <div className="flex items-center gap-1 sm:gap-2">
+                {indicator}
+              </div>
+            )}
+            {index < steps.length - 1 && (
+              <div className="relative h-[2px] w-4 sm:w-8 md:w-12 bg-border">
+                {isCompleted && (
+                  <motion.div
+                    className="absolute inset-0 bg-cyan"
+                    initial={{ scaleX: 0 }}
+                    animate={{ scaleX: 1 }}
+                    transition={{ duration: 0.4, delay: index * 0.15 }}
+                    style={{ transformOrigin: "left" }}
+                  />
+                )}
+              </div>
+            )}
           </div>
-          {index < steps.length - 1 && (
-            <div className="relative h-[2px] w-4 sm:w-8 md:w-12 bg-border">
-              {index < currentStep && (
-                <motion.div
-                  className="absolute inset-0 bg-cyan"
-                  initial={{ scaleX: 0 }}
-                  animate={{ scaleX: 1 }}
-                  transition={{ duration: 0.4, delay: index * 0.15 }}
-                  style={{ transformOrigin: "left" }}
-                />
-              )}
-            </div>
-          )}
-        </div>
-      ))}
+        );
+      })}
     </div>
   );
 }


### PR DESCRIPTION

## Summary

Make completed step indicators in the header clickable links so users can navigate back to prior steps. Add a "Back to Gap Analysis" button on the learning plan page and a "View Learning Plan" button on the gap analysis page for sessions with an existing plan.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Knowledge base contribution
- [ ] Documentation
- [ ] Infrastructure / CI
- [x] Refactoring

## Related Issues

Closes #122

## Checklist

- [x] I have run `make check` and all checks pass
- [x] I have added tests for new functionality
- [x] I have updated documentation if needed
- [x] My changes do not introduce new warnings
