### PR TITLE
fix: read assessed bloom from knowledge graph in content pipeline gap_prioritizer

### DIFF
--- a/backend/app/agents/content_nodes.py
+++ b/backend/app/agents/content_nodes.py
@@ -104,7 +104,7 @@ async def gap_prioritizer(state: LearningMaterialState) -> dict:
     # Build lookup for candidate's assessed bloom from the knowledge graph.
     # gap_nodes[].bloom_level stores the TARGET bloom (from gap_analyzer),
     # so we source the actual current bloom from knowledge_graph nodes.
-    kg_nodes = assessment_data.get("knowledge_graph", {}).get("nodes", [])
+    kg_nodes = (assessment_data.get("knowledge_graph") or {}).get("nodes") or []
     assessed_bloom: dict[str, str] = {
         n["concept"]: n.get("bloom_level", "remember") for n in kg_nodes if n.get("concept")
     }

--- a/backend/tests/test_content_nodes.py
+++ b/backend/tests/test_content_nodes.py
@@ -356,6 +356,42 @@ class TestGapPrioritizer:
         assert len(gaps) == 1
         assert gaps[0].current_bloom == 1  # defaulted to remember
 
+    @pytest.mark.asyncio
+    @patch("app.agents.content_nodes.get_db")
+    async def test_handles_null_knowledge_graph(self, mock_get_db: AsyncMock, setup_db) -> None:
+        """knowledge_graph can be None (nullable DB column); must not crash."""
+        from tests.conftest import _override_get_db
+
+        mock_get_db.side_effect = _override_get_db
+
+        assessment_data = {
+            "session_id": "sess-test",
+            "knowledge_graph": None,
+            "gap_nodes": [
+                {
+                    "concept": "http_fundamentals",
+                    "confidence": 0.0,
+                    "bloom_level": "understand",
+                    "prerequisites": [],
+                    "evidence": [],
+                },
+            ],
+            "learning_plan": None,
+            "proficiency_scores": [],
+        }
+
+        state: LearningMaterialState = {
+            "session_id": "sess-test",
+            "domain": "backend_engineering",
+            "assessment_result_data": assessment_data,
+        }
+        result = await gap_prioritizer(state)
+        gaps = result["prioritized_gaps"]
+
+        # Should still work, defaulting all concepts to "remember"
+        assert len(gaps) == 1
+        assert gaps[0].current_bloom == 1
+
 
 # ---------------------------------------------------------------------------
 # Objective Generator Tests


### PR DESCRIPTION
## Summary
- Content generation pipeline's `gap_prioritizer` always returned an empty list, causing all downstream nodes (objective_generator, generate_all_content, validate_all_content) to produce no output
- Root cause: `gap_analyzer` stores the **target** bloom level in `gap_nodes[].bloom_level`, but `gap_prioritizer` read it as the candidate's **current** bloom — since both matched the taxonomy target, the filter `target_bloom <= current_bloom` was always true, skipping every gap
- Fix: source the candidate's actual assessed bloom from `knowledge_graph` nodes in `assessment_result_data`, defaulting un-assessed concepts to "remember" (level 1)

## Test plan
- [x] `make check` passes (lint + typecheck + test + build)
- [x] 3 regression tests added in `test_content_nodes.py::TestGapPrioritizer`
- [x] E2E verified: completed a full Senior assessment with 4 skills, confirmed 4 `MaterialResult` rows generated (previously always 0)
- [x] All 433 backend tests pass

## Related
Prerequisite for #134

🤖 Generated with [Claude Code](https://claude.com/claude-code)