### PR TITLE
enh: extract graph state models into semantic model modules

### DIFF
--- a/backend/app/agents/gap_analyzer.py
+++ b/backend/app/agents/gap_analyzer.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
-from app.graph.state import AssessmentState, KnowledgeGraph, KnowledgeNode
+from app.graph.state import AssessmentState
+from app.models.knowledge import KnowledgeGraph, KnowledgeNode
 
 # Discount applied when inferring confidence from assessed prerequisites.
 # E.g. if a prerequisite was assessed at 0.82, the dependent concept gets 0.82 * 0.5 = 0.41.

--- a/backend/app/agents/gap_enricher.py
+++ b/backend/app/agents/gap_enricher.py
@@ -4,13 +4,9 @@ from typing import Literal
 
 from app.agents.gap_analyzer import get_effective_confidence
 from app.agents.schemas import GapEnrichmentOutput
-from app.graph.state import (
-    AssessmentState,
-    EnrichedGapAnalysis,
-    EnrichedGapItem,
-    KnowledgeGraph,
-    KnowledgeNode,
-)
+from app.graph.state import AssessmentState
+from app.models.enriched_gap import EnrichedGapAnalysis, EnrichedGapItem
+from app.models.knowledge import KnowledgeGraph, KnowledgeNode
 from app.prompts.gap_enricher import GAP_ENRICHMENT_PROMPT_FOOTER, GAP_ENRICHMENT_PROMPT_HEADER
 from app.services.ai import ainvoke_structured
 

--- a/backend/app/agents/knowledge_mapper.py
+++ b/backend/app/agents/knowledge_mapper.py
@@ -1,15 +1,10 @@
 from __future__ import annotations
 
 from app.agents.gap_analyzer import PREREQ_DISCOUNT
-from app.graph.state import (
-    AgendaItem,
-    AssessmentState,
-    BloomLevel,
-    KnowledgeGraph,
-    KnowledgeNode,
-    TopicStatus,
-    bloom_index,
-)
+from app.graph.state import AssessmentState
+from app.models.assessment_pipeline import AgendaItem, TopicStatus
+from app.models.bloom import BloomLevel, bloom_index
+from app.models.knowledge import KnowledgeGraph, KnowledgeNode
 
 
 def update_knowledge_graph(state: AssessmentState) -> dict:

--- a/backend/app/agents/plan_generator.py
+++ b/backend/app/agents/plan_generator.py
@@ -1,12 +1,8 @@
 from __future__ import annotations
 
 from app.agents.schemas import PlanOutput
-from app.graph.state import (
-    AssessmentState,
-    LearningPhase,
-    LearningPlan,
-    Resource,
-)
+from app.graph.state import AssessmentState
+from app.models.pipeline_plan import LearningPhase, LearningPlan, Resource
 from app.prompts.plan_generator import PLAN_GEN_PROMPT
 from app.services.ai import ainvoke_structured
 

--- a/backend/app/agents/question_generator.py
+++ b/backend/app/agents/question_generator.py
@@ -3,7 +3,9 @@ from __future__ import annotations
 import uuid
 
 from app.agents.schemas import QuestionOutput
-from app.graph.state import AssessmentState, BloomLevel, Question
+from app.graph.state import AssessmentState
+from app.models.assessment_pipeline import Question
+from app.models.bloom import BloomLevel
 from app.prompts.question_gen import QUESTION_GEN_PROMPT
 from app.services.ai import ainvoke_structured
 

--- a/backend/app/agents/response_evaluator.py
+++ b/backend/app/agents/response_evaluator.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
 from app.agents.schemas import EvaluationOutput
-from app.graph.state import AssessmentState, BloomLevel, EvaluationResult
+from app.graph.state import AssessmentState
+from app.models.assessment_pipeline import EvaluationResult
+from app.models.bloom import BloomLevel
 from app.prompts.evaluator import EVALUATOR_PROMPT
 from app.services.ai import ainvoke_structured
 

--- a/backend/app/graph/pipeline.py
+++ b/backend/app/graph/pipeline.py
@@ -10,14 +10,9 @@ from app.agents.plan_generator import generate_plan
 from app.agents.question_generator import generate_question
 from app.agents.response_evaluator import evaluate_response
 from app.graph.router import MAX_TOPICS, decide_branch, get_deeper_bloom, get_next_topic
-from app.graph.state import (
-    LEVEL_BLOOM_MAP,
-    AssessmentState,
-    BloomLevel,
-    Question,
-    Response,
-    TopicStatus,
-)
+from app.graph.state import AssessmentState
+from app.models.assessment_pipeline import Question, Response, TopicStatus
+from app.models.bloom import LEVEL_BLOOM_MAP, BloomLevel
 
 # --- Agenda node ---
 

--- a/backend/app/graph/router.py
+++ b/backend/app/graph/router.py
@@ -1,12 +1,8 @@
 from __future__ import annotations
 
-from app.graph.state import (
-    LEVEL_BLOOM_MAP,
-    AssessmentState,
-    BloomLevel,
-    TopicStatus,
-    bloom_index,
-)
+from app.graph.state import AssessmentState
+from app.models.assessment_pipeline import TopicStatus
+from app.models.bloom import LEVEL_BLOOM_MAP, BloomLevel, bloom_index
 
 # Thresholds
 MAX_TOPICS = 10
@@ -143,7 +139,7 @@ def get_deeper_bloom(state: AssessmentState) -> dict:
     """Advance to the next Bloom level for the current topic."""
     current_bloom = state.get("current_bloom_level", BloomLevel.understand)
     idx = bloom_index(current_bloom)
-    from app.graph.state import BLOOM_ORDER
+    from app.models.bloom import BLOOM_ORDER
 
     next_bloom = BLOOM_ORDER[min(idx + 1, len(BLOOM_ORDER) - 1)]
 

--- a/backend/app/graph/state.py
+++ b/backend/app/graph/state.py
@@ -1,144 +1,44 @@
 from __future__ import annotations
 
-from enum import StrEnum
-from typing import Literal, TypedDict
+from typing import TypedDict
 
-from app.models.base import CamelModel
+from app.models.assessment_pipeline import (
+    THOROUGHNESS_CAPS,
+    AgendaItem,
+    EvaluationResult,
+    Question,
+    Response,
+    Thoroughness,
+    TopicStatus,
+)
+from app.models.bloom import BLOOM_ORDER, LEVEL_BLOOM_MAP, BloomLevel, bloom_index
+from app.models.enriched_gap import EnrichedGapAnalysis, EnrichedGapItem
+from app.models.knowledge import KnowledgeGraph, KnowledgeNode
+from app.models.pipeline_plan import LearningPhase, LearningPlan, Resource
 
-
-class BloomLevel(StrEnum):
-    remember = "remember"
-    understand = "understand"
-    apply = "apply"
-    analyze = "analyze"
-    evaluate = "evaluate"
-    create = "create"
-
-
-class TopicStatus(StrEnum):
-    pending = "pending"
-    active = "active"
-    assessed = "assessed"
-    inferred = "inferred"
-    skipped = "skipped"
-
-
-class Thoroughness(StrEnum):
-    quick = "quick"
-    standard = "standard"
-    thorough = "thorough"
-
-
-THOROUGHNESS_CAPS: dict[Thoroughness, int] = {
-    Thoroughness.quick: 2,
-    Thoroughness.standard: 4,
-    Thoroughness.thorough: 6,
-}
-
-
-BLOOM_ORDER: list[BloomLevel] = list(BloomLevel)
-
-LEVEL_BLOOM_MAP: dict[str, BloomLevel] = {
-    "junior": BloomLevel.understand,
-    "mid": BloomLevel.apply,
-    "senior": BloomLevel.analyze,
-    "staff": BloomLevel.evaluate,
-}
-
-
-def bloom_index(level: BloomLevel) -> int:
-    return BLOOM_ORDER.index(level)
-
-
-class AgendaItem(CamelModel):
-    concept: str
-    level: str  # "junior", "mid", "senior", "staff"
-    status: TopicStatus = TopicStatus.pending
-    confidence: float = 0.0
-    prerequisites: list[str] = []
-
-
-class Question(CamelModel):
-    id: str
-    topic: str
-    bloom_level: BloomLevel
-    text: str
-    question_type: str  # conceptual, scenario, debugging, design
-
-
-class Response(CamelModel):
-    question_id: str
-    text: str
-
-
-class EvaluationResult(CamelModel):
-    question_id: str
-    confidence: float  # 0.0-1.0
-    bloom_level: BloomLevel
-    evidence: list[str]
-
-
-class KnowledgeNode(CamelModel):
-    concept: str
-    confidence: float  # 0.0-1.0
-    bloom_level: BloomLevel
-    prerequisites: list[str] = []
-    evidence: list[str] = []
-
-
-class KnowledgeGraph(CamelModel):
-    nodes: list[KnowledgeNode] = []
-    edges: list[tuple[str, str]] = []  # (prerequisite, dependent)
-
-    def get_node(self, concept: str) -> KnowledgeNode | None:
-        for node in self.nodes:
-            if node.concept == concept:
-                return node
-        return None
-
-    def upsert_node(self, node: KnowledgeNode) -> None:
-        for i, existing in enumerate(self.nodes):
-            if existing.concept == node.concept:
-                self.nodes[i] = node
-                return
-        self.nodes.append(node)
-
-
-class Resource(CamelModel):
-    type: str  # video, article, project, exercise
-    title: str
-    url: str | None = None
-
-
-class LearningPhase(CamelModel):
-    phase_number: int
-    title: str
-    concepts: list[str]
-    rationale: str
-    resources: list[Resource]
-    estimated_hours: float
-
-
-class LearningPlan(CamelModel):
-    phases: list[LearningPhase]
-    total_hours: float
-    summary: str
-
-
-class EnrichedGapItem(CamelModel):
-    skill_id: str
-    skill_name: str
-    current_level: int  # 0-100
-    target_level: int  # 0-100
-    gap: int  # target - current
-    priority: Literal["critical", "high", "medium", "low"]
-    recommendation: str
-
-
-class EnrichedGapAnalysis(CamelModel):
-    overall_readiness: int  # 0-100
-    summary: str
-    gaps: list[EnrichedGapItem]
+# Re-export all symbols so existing `from app.graph.state import X` still works.
+__all__ = [
+    "BLOOM_ORDER",
+    "LEVEL_BLOOM_MAP",
+    "THOROUGHNESS_CAPS",
+    "AgendaItem",
+    "AssessmentState",
+    "BloomLevel",
+    "EnrichedGapAnalysis",
+    "EnrichedGapItem",
+    "EvaluationResult",
+    "KnowledgeGraph",
+    "KnowledgeNode",
+    "LearningPhase",
+    "LearningPlan",
+    "Question",
+    "Resource",
+    "Response",
+    "Thoroughness",
+    "TopicStatus",
+    "bloom_index",
+    "make_initial_state",
+]
 
 
 class AssessmentState(TypedDict, total=False):

--- a/backend/app/knowledge_base/loader.py
+++ b/backend/app/knowledge_base/loader.py
@@ -5,8 +5,10 @@ from pathlib import Path
 
 import yaml
 
-from app.graph.state import AgendaItem, BloomLevel, KnowledgeGraph, KnowledgeNode, TopicStatus
 from app.knowledge_base.schema import LEVEL_ORDER, KnowledgeBaseSchema
+from app.models.assessment_pipeline import AgendaItem, TopicStatus
+from app.models.bloom import BloomLevel
+from app.models.knowledge import KnowledgeGraph, KnowledgeNode
 
 _KB_DIR = Path(__file__).parent
 _cache: dict[str, KnowledgeBaseSchema] = {}

--- a/backend/app/models/assessment_pipeline.py
+++ b/backend/app/models/assessment_pipeline.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+from enum import StrEnum
+
+from app.models.base import CamelModel
+from app.models.bloom import BloomLevel
+
+
+class TopicStatus(StrEnum):
+    pending = "pending"
+    active = "active"
+    assessed = "assessed"
+    inferred = "inferred"
+    skipped = "skipped"
+
+
+class Thoroughness(StrEnum):
+    quick = "quick"
+    standard = "standard"
+    thorough = "thorough"
+
+
+THOROUGHNESS_CAPS: dict[Thoroughness, int] = {
+    Thoroughness.quick: 2,
+    Thoroughness.standard: 4,
+    Thoroughness.thorough: 6,
+}
+
+
+class AgendaItem(CamelModel):
+    concept: str
+    level: str  # "junior", "mid", "senior", "staff"
+    status: TopicStatus = TopicStatus.pending
+    confidence: float = 0.0
+    prerequisites: list[str] = []
+
+
+class Question(CamelModel):
+    id: str
+    topic: str
+    bloom_level: BloomLevel
+    text: str
+    question_type: str  # conceptual, scenario, debugging, design
+
+
+class Response(CamelModel):
+    question_id: str
+    text: str
+
+
+class EvaluationResult(CamelModel):
+    question_id: str
+    confidence: float  # 0.0-1.0
+    bloom_level: BloomLevel
+    evidence: list[str]

--- a/backend/app/models/bloom.py
+++ b/backend/app/models/bloom.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+from enum import StrEnum
+
+
+class BloomLevel(StrEnum):
+    remember = "remember"
+    understand = "understand"
+    apply = "apply"
+    analyze = "analyze"
+    evaluate = "evaluate"
+    create = "create"
+
+
+BLOOM_ORDER: list[BloomLevel] = list(BloomLevel)
+
+LEVEL_BLOOM_MAP: dict[str, BloomLevel] = {
+    "junior": BloomLevel.understand,
+    "mid": BloomLevel.apply,
+    "senior": BloomLevel.analyze,
+    "staff": BloomLevel.evaluate,
+}
+
+
+def bloom_index(level: BloomLevel) -> int:
+    return BLOOM_ORDER.index(level)

--- a/backend/app/models/enriched_gap.py
+++ b/backend/app/models/enriched_gap.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+from typing import Literal
+
+from app.models.base import CamelModel
+
+
+class EnrichedGapItem(CamelModel):
+    skill_id: str
+    skill_name: str
+    current_level: int  # 0-100
+    target_level: int  # 0-100
+    gap: int  # target - current
+    priority: Literal["critical", "high", "medium", "low"]
+    recommendation: str
+
+
+class EnrichedGapAnalysis(CamelModel):
+    overall_readiness: int  # 0-100
+    summary: str
+    gaps: list[EnrichedGapItem]

--- a/backend/app/models/knowledge.py
+++ b/backend/app/models/knowledge.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+from app.models.base import CamelModel
+from app.models.bloom import BloomLevel
+
+
+class KnowledgeNode(CamelModel):
+    concept: str
+    confidence: float  # 0.0-1.0
+    bloom_level: BloomLevel
+    prerequisites: list[str] = []
+    evidence: list[str] = []
+
+
+class KnowledgeGraph(CamelModel):
+    nodes: list[KnowledgeNode] = []
+    edges: list[tuple[str, str]] = []  # (prerequisite, dependent)
+
+    def get_node(self, concept: str) -> KnowledgeNode | None:
+        for node in self.nodes:
+            if node.concept == concept:
+                return node
+        return None
+
+    def upsert_node(self, node: KnowledgeNode) -> None:
+        for i, existing in enumerate(self.nodes):
+            if existing.concept == node.concept:
+                self.nodes[i] = node
+                return
+        self.nodes.append(node)

--- a/backend/app/models/pipeline_plan.py
+++ b/backend/app/models/pipeline_plan.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+from app.models.base import CamelModel
+
+
+class Resource(CamelModel):
+    type: str  # video, article, project, exercise
+    title: str
+    url: str | None = None
+
+
+class LearningPhase(CamelModel):
+    phase_number: int
+    title: str
+    concepts: list[str]
+    rationale: str
+    resources: list[Resource]
+    estimated_hours: float
+
+
+class LearningPlan(CamelModel):
+    phases: list[LearningPhase]
+    total_hours: float
+    summary: str

--- a/backend/app/services/assessment_mappers.py
+++ b/backend/app/services/assessment_mappers.py
@@ -10,7 +10,6 @@ from __future__ import annotations
 from app.agents.gap_analyzer import analyze_gaps
 from app.agents.gap_enricher import _compute_overall_readiness, _compute_priority
 from app.db import AssessmentResult, AssessmentSession
-from app.graph.state import BloomLevel, KnowledgeGraph, KnowledgeNode
 from app.knowledge_base.loader import (
     get_target_graph,
     get_target_graph_for_concepts,
@@ -25,7 +24,9 @@ from app.models.assessment_api import (
     LearningPlanOut,
     ResourceOut,
 )
+from app.models.bloom import BloomLevel
 from app.models.gap_analysis import GapAnalysis, GapItem
+from app.models.knowledge import KnowledgeGraph, KnowledgeNode
 
 # ---------------------------------------------------------------------------
 # DTO builders

--- a/backend/app/services/assessment_service.py
+++ b/backend/app/services/assessment_service.py
@@ -30,11 +30,7 @@ from app.exceptions import (
     SessionTimedOutError,
 )
 from app.graph.router import MAX_TOPICS
-from app.graph.state import (
-    THOROUGHNESS_CAPS,
-    Thoroughness,
-    make_initial_state,
-)
+from app.graph.state import make_initial_state
 from app.knowledge_base.loader import (
     get_all_topics,
     get_target_graph,
@@ -47,6 +43,7 @@ from app.models.assessment_api import (
     AssessmentStartResponse,
     KnowledgeGraphOut,
 )
+from app.models.assessment_pipeline import THOROUGHNESS_CAPS, Thoroughness
 from app.models.events import AssessmentEvent, CompleteEvent, ErrorEvent, QuestionEvent
 from app.repositories import result_repo, session_repo
 from app.routes.export_utils import build_assessment_markdown

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -11,17 +11,11 @@ from sqlalchemy.pool import NullPool
 
 from app.db import AssessmentResult, AssessmentSession, AuthMethod, Base, get_db
 from app.deps import AuthUser, get_current_user, get_user_api_key
-from app.graph.state import (
-    AssessmentState,
-    BloomLevel,
-    EvaluationResult,
-    KnowledgeGraph,
-    KnowledgeNode,
-    Question,
-    Response,
-    make_initial_state,
-)
+from app.graph.state import AssessmentState, make_initial_state
 from app.main import register_anthropic_error_handlers, register_assessment_error_handlers
+from app.models.assessment_pipeline import EvaluationResult, Question, Response
+from app.models.bloom import BloomLevel
+from app.models.knowledge import KnowledgeGraph, KnowledgeNode
 from app.routes.api_keys import router as api_keys_router
 from app.routes.assessment import router as assessment_router
 from app.routes.auth import router as auth_router

--- a/backend/tests/test_agents.py
+++ b/backend/tests/test_agents.py
@@ -10,15 +10,10 @@ from app.agents.knowledge_mapper import update_knowledge_graph
 from app.agents.question_generator import generate_question
 from app.agents.response_evaluator import evaluate_response
 from app.agents.schemas import EvaluationOutput, QuestionOutput
-from app.graph.state import (
-    BloomLevel,
-    EvaluationResult,
-    KnowledgeGraph,
-    KnowledgeNode,
-    Question,
-    Response,
-    make_initial_state,
-)
+from app.graph.state import make_initial_state
+from app.models.assessment_pipeline import EvaluationResult, Question, Response
+from app.models.bloom import BloomLevel
+from app.models.knowledge import KnowledgeGraph, KnowledgeNode
 
 
 class TestKnowledgeMapper:

--- a/backend/tests/test_assessment_mappers.py
+++ b/backend/tests/test_assessment_mappers.py
@@ -4,9 +4,10 @@ from __future__ import annotations
 
 from unittest.mock import MagicMock
 
-from app.graph.state import BloomLevel, KnowledgeGraph, KnowledgeNode
 from app.models.assessment_api import KnowledgeGraphOut, LearningPlanOut
+from app.models.bloom import BloomLevel
 from app.models.gap_analysis import GapAnalysis
+from app.models.knowledge import KnowledgeGraph, KnowledgeNode
 from app.services.assessment_mappers import (
     build_gap_analysis_out,
     build_kg_out,

--- a/backend/tests/test_assessment_routes.py
+++ b/backend/tests/test_assessment_routes.py
@@ -10,15 +10,10 @@ from httpx import ASGITransport, AsyncClient
 from sqlalchemy import select
 
 from app.db import AssessmentResult, AssessmentSession, User
-from app.graph.state import (
-    BloomLevel,
-    EnrichedGapAnalysis,
-    KnowledgeGraph,
-    KnowledgeNode,
-    LearningPhase,
-    LearningPlan,
-    Resource,
-)
+from app.models.bloom import BloomLevel
+from app.models.enriched_gap import EnrichedGapAnalysis
+from app.models.knowledge import KnowledgeGraph, KnowledgeNode
+from app.models.pipeline_plan import LearningPhase, LearningPlan, Resource
 from tests.conftest import (
     FULL_LEARNING_PLAN,
     _mock_graph,

--- a/backend/tests/test_assessment_service.py
+++ b/backend/tests/test_assessment_service.py
@@ -13,16 +13,11 @@ from app.exceptions import (
     SessionAlreadyCompletedError,
     SessionTimedOutError,
 )
-from app.graph.state import (
-    BloomLevel,
-    EnrichedGapAnalysis,
-    KnowledgeGraph,
-    KnowledgeNode,
-    LearningPhase,
-    LearningPlan,
-    Resource,
-)
+from app.models.bloom import BloomLevel
+from app.models.enriched_gap import EnrichedGapAnalysis
 from app.models.events import CompleteEvent, ErrorEvent, QuestionEvent
+from app.models.knowledge import KnowledgeGraph, KnowledgeNode
+from app.models.pipeline_plan import LearningPhase, LearningPlan, Resource
 from app.services.assessment_service import (
     extract_interrupt,
     get_assessment_report,

--- a/backend/tests/test_gap_enricher.py
+++ b/backend/tests/test_gap_enricher.py
@@ -6,7 +6,8 @@ import pytest
 
 from app.agents.gap_analyzer import PREREQ_DISCOUNT
 from app.agents.gap_enricher import _compute_overall_readiness, _compute_priority
-from app.graph.state import BloomLevel, KnowledgeGraph, KnowledgeNode
+from app.models.bloom import BloomLevel
+from app.models.knowledge import KnowledgeGraph, KnowledgeNode
 
 
 def _node(concept: str, confidence: float) -> KnowledgeNode:

--- a/backend/tests/test_knowledge_base.py
+++ b/backend/tests/test_knowledge_base.py
@@ -8,7 +8,6 @@ from app.agents.gap_analyzer import (
     analyze_gaps,
     get_effective_confidence,
 )
-from app.graph.state import BloomLevel, KnowledgeGraph, KnowledgeNode, TopicStatus
 from app.knowledge_base.loader import (
     build_topic_agenda,
     clear_cache,
@@ -18,6 +17,9 @@ from app.knowledge_base.loader import (
     load_knowledge_base,
     map_skills_to_domain,
 )
+from app.models.assessment_pipeline import TopicStatus
+from app.models.bloom import BloomLevel
+from app.models.knowledge import KnowledgeGraph, KnowledgeNode
 
 
 @pytest.fixture(autouse=True)

--- a/backend/tests/test_pipeline.py
+++ b/backend/tests/test_pipeline.py
@@ -3,7 +3,8 @@
 import pytest
 
 from app.graph.pipeline import build_graph, compile_graph
-from app.graph.state import LEVEL_BLOOM_MAP, BloomLevel, make_initial_state
+from app.graph.state import make_initial_state
+from app.models.bloom import LEVEL_BLOOM_MAP, BloomLevel
 
 
 class TestGraphStructure:
@@ -98,7 +99,7 @@ class TestBuildAgendaBloomMapping:
         from app.graph import pipeline as pipeline_mod
 
         # Stub agenda builder to return a single item
-        from app.graph.state import AgendaItem
+        from app.models.assessment_pipeline import AgendaItem
 
         def fake_agenda(domain, level, skill_ids=None):
             return [AgendaItem(concept="test_topic", level=level)]
@@ -120,7 +121,7 @@ class TestBuildAgendaBloomMapping:
 
     def test_unknown_level_defaults_to_apply(self, monkeypatch):
         from app.graph import pipeline as pipeline_mod
-        from app.graph.state import AgendaItem
+        from app.models.assessment_pipeline import AgendaItem
 
         def fake_agenda(domain, level, skill_ids=None):
             return [AgendaItem(concept="test_topic", level=level)]

--- a/backend/tests/test_router.py
+++ b/backend/tests/test_router.py
@@ -1,16 +1,10 @@
 """Tests for the branch router (deterministic routing logic)."""
 
 from app.graph.router import MAX_TOPICS, decide_branch, get_deeper_bloom, get_next_topic
-from app.graph.state import (
-    AgendaItem,
-    BloomLevel,
-    EvaluationResult,
-    KnowledgeGraph,
-    KnowledgeNode,
-    Question,
-    TopicStatus,
-    make_initial_state,
-)
+from app.graph.state import make_initial_state
+from app.models.assessment_pipeline import AgendaItem, EvaluationResult, Question, TopicStatus
+from app.models.bloom import BloomLevel
+from app.models.knowledge import KnowledgeGraph, KnowledgeNode
 
 
 def _make_state(**overrides):

--- a/backend/tests/test_state.py
+++ b/backend/tests/test_state.py
@@ -1,18 +1,10 @@
 """Tests for state schema validation and instantiation."""
 
-from app.graph.state import (
-    BLOOM_ORDER,
-    BloomLevel,
-    EvaluationResult,
-    KnowledgeGraph,
-    KnowledgeNode,
-    LearningPhase,
-    LearningPlan,
-    Question,
-    Resource,
-    bloom_index,
-    make_initial_state,
-)
+from app.graph.state import make_initial_state
+from app.models.assessment_pipeline import EvaluationResult, Question
+from app.models.bloom import BLOOM_ORDER, BloomLevel, bloom_index
+from app.models.knowledge import KnowledgeGraph, KnowledgeNode
+from app.models.pipeline_plan import LearningPhase, LearningPlan, Resource
 
 
 class TestBloomLevel:


### PR DESCRIPTION
## Summary
- Extract all domain models from `graph/state.py` into 5 dedicated model files grouped by semantic meaning:
  - `models/bloom.py` — Bloom taxonomy (`BloomLevel`, `BLOOM_ORDER`, `LEVEL_BLOOM_MAP`, `bloom_index`)
  - `models/knowledge.py` — Knowledge graph (`KnowledgeNode`, `KnowledgeGraph`)
  - `models/assessment_pipeline.py` — Assessment execution (`TopicStatus`, `Thoroughness`, `AgendaItem`, `Question`, `Response`, `EvaluationResult`)
  - `models/enriched_gap.py` — Enriched gap analysis (`EnrichedGapItem`, `EnrichedGapAnalysis`)
  - `models/pipeline_plan.py` — Pipeline learning plan (`Resource`, `LearningPhase`, `LearningPlan`)
- `graph/state.py` now only holds `AssessmentState` and `make_initial_state()`, with re-exports for backward compatibility
- Updated all 27 import sites across agents, services, and tests to import directly from new model locations

## Test plan
- [x] All 144 affected tests pass (`pytest tests/ -x -q`)
- [x] All imports verified (`python -c "from app.models.bloom import ..."`)
- [x] Pre-commit hooks pass (ruff format + ruff check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)