### PR TITLE
fix: auto-resync frontend node_modules across stale dev volume

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -6,6 +6,13 @@ WORKDIR /app
 COPY package.json package-lock.json* ./
 RUN npm ci
 
+# Entrypoint keeps node_modules in sync with package-lock.json when the
+# dev-mode anonymous volume outlives dependency changes. Only used by the
+# dev stack (docker-compose.dev.yml); production inherits a different stage.
+COPY docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
+RUN chmod +x /usr/local/bin/docker-entrypoint.sh
+ENTRYPOINT ["/usr/local/bin/docker-entrypoint.sh"]
+
 # -- Stage: build --
 FROM deps AS build
 

--- a/frontend/docker-entrypoint.sh
+++ b/frontend/docker-entrypoint.sh
@@ -6,13 +6,17 @@
 # Linux-native install. However, the anonymous volume persists across rebuilds,
 # so when package.json gains a new dependency the volume reattaches stale
 # node_modules on top of the freshly-installed image. This script detects that
-# mismatch at container start and runs `npm install` to resync.
+# mismatch at container start and runs `npm ci` to resync.
 #
 # Decision logic:
-#   1. If node_modules is missing entirely → run npm install.
+#   1. If node_modules is missing or the install marker is absent → install.
 #   2. If package-lock.json is newer than node_modules/.package-lock.json
-#      (the marker npm writes after every successful install) → run npm install.
+#      (the marker npm writes after every successful install) → install.
 #   3. Otherwise → skip; deps are already in sync.
+#
+# Install command: `npm ci` when a lockfile exists (deterministic, never
+# rewrites the host lockfile via the bind mount), falling back to
+# `npm install` only if package-lock.json is absent.
 set -e
 
 MARKER="node_modules/.package-lock.json"
@@ -32,10 +36,26 @@ needs_install() {
 }
 
 if needs_install; then
-  echo "[entrypoint] package-lock.json changed or node_modules missing — running npm install..."
-  npm install --no-audit --no-fund
+  if [ -f "$LOCKFILE" ]; then
+    # Prefer `npm ci` for determinism: it refuses to run when package.json
+    # and package-lock.json disagree, and it never rewrites the lockfile
+    # (which matters because /app is a host bind mount — `npm install`
+    # would silently edit the developer's checked-in lockfile on startup).
+    echo "[entrypoint] package-lock.json changed or node_modules missing — running npm ci..."
+    npm ci --no-audit --no-fund
+  else
+    # No lockfile: fall back to `npm install` so a bare `package.json`
+    # still produces a working tree instead of failing hard.
+    echo "[entrypoint] node_modules missing and no package-lock.json — running npm install..."
+    npm install --no-audit --no-fund
+  fi
 else
   echo "[entrypoint] node_modules is up to date with package-lock.json — skipping install."
+fi
+
+if [ "$#" -eq 0 ]; then
+  echo "[entrypoint] error: no command provided to docker-entrypoint.sh" >&2
+  exit 1
 fi
 
 exec "$@"

--- a/frontend/docker-entrypoint.sh
+++ b/frontend/docker-entrypoint.sh
@@ -19,6 +19,14 @@
 # `npm install` only if package-lock.json is absent.
 set -e
 
+# Fail fast if the caller forgot to pass a CMD. `exec ""` would otherwise
+# silently exit 127 in some shells, and we'd waste a full `npm ci` before
+# hitting that failure — so gate on argv up front.
+if [ "$#" -eq 0 ]; then
+  echo "[entrypoint] error: no command provided to docker-entrypoint.sh" >&2
+  exit 1
+fi
+
 MARKER="node_modules/.package-lock.json"
 LOCKFILE="package-lock.json"
 
@@ -49,13 +57,10 @@ if needs_install; then
     echo "[entrypoint] node_modules missing and no package-lock.json — running npm install..."
     npm install --no-audit --no-fund
   fi
-else
+elif [ -f "$LOCKFILE" ]; then
   echo "[entrypoint] node_modules is up to date with package-lock.json — skipping install."
-fi
-
-if [ "$#" -eq 0 ]; then
-  echo "[entrypoint] error: no command provided to docker-entrypoint.sh" >&2
-  exit 1
+else
+  echo "[entrypoint] node_modules present and no package-lock.json — skipping install."
 fi
 
 exec "$@"

--- a/frontend/docker-entrypoint.sh
+++ b/frontend/docker-entrypoint.sh
@@ -1,0 +1,41 @@
+#!/bin/sh
+# docker-entrypoint.sh — Refresh node_modules if package-lock.json has changed.
+#
+# Context: docker-compose.dev.yml uses an anonymous volume at /app/node_modules
+# to prevent the host's macOS-native node_modules from shadowing the container's
+# Linux-native install. However, the anonymous volume persists across rebuilds,
+# so when package.json gains a new dependency the volume reattaches stale
+# node_modules on top of the freshly-installed image. This script detects that
+# mismatch at container start and runs `npm install` to resync.
+#
+# Decision logic:
+#   1. If node_modules is missing entirely → run npm install.
+#   2. If package-lock.json is newer than node_modules/.package-lock.json
+#      (the marker npm writes after every successful install) → run npm install.
+#   3. Otherwise → skip; deps are already in sync.
+set -e
+
+MARKER="node_modules/.package-lock.json"
+LOCKFILE="package-lock.json"
+
+needs_install() {
+  if [ ! -d node_modules ] || [ ! -f "$MARKER" ]; then
+    return 0
+  fi
+  if [ ! -f "$LOCKFILE" ]; then
+    return 1
+  fi
+  if [ "$LOCKFILE" -nt "$MARKER" ]; then
+    return 0
+  fi
+  return 1
+}
+
+if needs_install; then
+  echo "[entrypoint] package-lock.json changed or node_modules missing — running npm install..."
+  npm install --no-audit --no-fund
+else
+  echo "[entrypoint] node_modules is up to date with package-lock.json — skipping install."
+fi
+
+exec "$@"

--- a/scripts/test-frontend-entrypoint.sh
+++ b/scripts/test-frontend-entrypoint.sh
@@ -4,12 +4,13 @@
 # Regression coverage for issue #159: the dev-mode anonymous volume at
 # /app/node_modules persisted across rebuilds, so new dependencies added to
 # package.json never made it into the running container. The entrypoint fixes
-# that by running `npm install` whenever package-lock.json is newer than the
-# install marker (or the marker is missing entirely).
+# that by running `npm ci` whenever package-lock.json is newer than the
+# install marker (or the marker is missing entirely). It falls back to
+# `npm install` only when the lockfile itself is absent.
 #
 # These tests run the entrypoint in a tmpdir with a fake `npm` on PATH so we
-# can assert whether `npm install` was invoked without touching the real
-# package manager.
+# can assert whether `npm ci`/`npm install` was invoked without touching the
+# real package manager.
 #
 # Usage: bash scripts/test-frontend-entrypoint.sh
 set -euo pipefail
@@ -93,15 +94,19 @@ run_entrypoint() {
   set -e
 }
 
-assert_npm_called() {
-  if grep -qE "^npm (install|ci)" "$SANDBOX/npm-calls.log"; then
-    pass
-  else
-    fail "expected npm install/ci to be called; log was: $(cat "$SANDBOX/npm-calls.log")"
+# Every success-path assertion must also verify the entrypoint exited 0.
+# Otherwise a scenario could silently pass even if the entrypoint crashed
+# *after* the npm step (e.g. a bug in the final `exec "$@"` guard).
+_assert_exit_success() {
+  if [ "${ENTRYPOINT_STATUS:-unset}" != "0" ]; then
+    fail "expected exit status 0, got '${ENTRYPOINT_STATUS:-unset}'; log was: $(cat "$SANDBOX/entrypoint.log")"
+    return 1
   fi
+  return 0
 }
 
 assert_npm_not_called() {
+  _assert_exit_success || return
   if [ -s "$SANDBOX/npm-calls.log" ]; then
     fail "expected npm to NOT be called; log was: $(cat "$SANDBOX/npm-calls.log")"
   else
@@ -110,6 +115,7 @@ assert_npm_not_called() {
 }
 
 assert_npm_ci_called() {
+  _assert_exit_success || return
   if grep -q "^npm ci" "$SANDBOX/npm-calls.log"; then
     pass
   else
@@ -118,6 +124,7 @@ assert_npm_ci_called() {
 }
 
 assert_npm_install_called() {
+  _assert_exit_success || return
   if grep -q "^npm install" "$SANDBOX/npm-calls.log" && \
      ! grep -q "^npm ci" "$SANDBOX/npm-calls.log"; then
     pass
@@ -202,24 +209,27 @@ else
 fi
 cleanup_sandbox
 
-# Scenario 7: fail loudly when no command is supplied.
+# Scenario 7: fail loudly when no command is supplied, BEFORE running npm.
 # Without this guard, `exec ""` would silently exit 127 in shells that allow
-# it; the entrypoint should print a clear diagnostic and exit non-zero.
-begin_test "errors out when no CMD is provided"
+# it; the entrypoint should print a clear diagnostic, exit non-zero, and
+# crucially NOT waste a full `npm ci` before discovering the missing CMD.
+# We deliberately stage a state that WOULD trigger npm ci (missing marker)
+# so that a regression moving the guard back below the install step would
+# be caught by the "npm log is empty" assertion.
+begin_test "errors out when no CMD is provided without running npm"
 make_sandbox
-touch "$SANDBOX/package.json"
-mkdir -p "$SANDBOX/node_modules"
-touch "$SANDBOX/node_modules/.package-lock.json"
-touch -t 202001010000 "$SANDBOX/package-lock.json"
-touch -t 202601010000 "$SANDBOX/node_modules/.package-lock.json"
+touch "$SANDBOX/package.json" "$SANDBOX/package-lock.json"
+# No node_modules → needs_install would return true if reached.
 set +e
 ( cd "$SANDBOX" && "$ENTRYPOINT" ) > "$SANDBOX/entrypoint.log" 2>&1
 no_cmd_status=$?
 set -e
-if [ "$no_cmd_status" -ne 0 ] && grep -q "no command provided" "$SANDBOX/entrypoint.log"; then
+if [ "$no_cmd_status" -ne 0 ] \
+   && grep -q "no command provided" "$SANDBOX/entrypoint.log" \
+   && [ ! -s "$SANDBOX/npm-calls.log" ]; then
   pass
 else
-  fail "expected non-zero exit + diagnostic; status=$no_cmd_status log=$(cat "$SANDBOX/entrypoint.log")"
+  fail "expected non-zero exit + diagnostic + no npm calls; status=$no_cmd_status log=$(cat "$SANDBOX/entrypoint.log") npm=$(cat "$SANDBOX/npm-calls.log")"
 fi
 cleanup_sandbox
 

--- a/scripts/test-frontend-entrypoint.sh
+++ b/scripts/test-frontend-entrypoint.sh
@@ -23,6 +23,10 @@ if [ ! -x "$ENTRYPOINT" ]; then
   exit 1
 fi
 
+# Snapshot PATH once so each sandbox starts from a clean slate instead of
+# accumulating dead tmpdir prefixes across tests.
+ORIGINAL_PATH="$PATH"
+
 TESTS_RUN=0
 TESTS_PASSED=0
 TESTS_FAILED=0
@@ -45,14 +49,14 @@ fail() {
 
 # make_sandbox — set up a tmpdir with a fake `npm` on PATH.
 # The fake npm records every invocation to $SANDBOX/npm-calls.log and
-# creates the install marker when called with `install`.
+# creates the install marker when called with `install` or `ci`.
 make_sandbox() {
   SANDBOX=$(mktemp -d)
   mkdir -p "$SANDBOX/bin"
   cat > "$SANDBOX/bin/npm" <<'EOF'
 #!/bin/sh
 echo "npm $*" >> "$SANDBOX/npm-calls.log"
-if [ "$1" = "install" ]; then
+if [ "$1" = "install" ] || [ "$1" = "ci" ]; then
   mkdir -p node_modules
   touch node_modules/.package-lock.json
 fi
@@ -60,28 +64,40 @@ EOF
   chmod +x "$SANDBOX/bin/npm"
   : > "$SANDBOX/npm-calls.log"
   export SANDBOX
-  export PATH="$SANDBOX/bin:$PATH"
+  # Reset PATH from the original snapshot so each sandbox adds exactly one
+  # prefix instead of stacking on previous runs.
+  export PATH="$SANDBOX/bin:$ORIGINAL_PATH"
 }
 
 cleanup_sandbox() {
   [ -n "${SANDBOX:-}" ] && rm -rf "$SANDBOX"
   SANDBOX=""
+  export PATH="$ORIGINAL_PATH"
 }
 
+# Remove any dangling sandbox even if a test aborts under `set -e`.
+trap cleanup_sandbox EXIT
+
 # run_entrypoint — run the entrypoint from inside the sandbox with `true` as CMD.
-# Returns the exit code. Captures stdout/stderr into $SANDBOX/entrypoint.log.
+# Captures the exit status without aborting the test script when the
+# entrypoint itself exits non-zero (`set -e` would otherwise kill us).
+# Stores the status in $ENTRYPOINT_STATUS and logs stdout/stderr to
+# $SANDBOX/entrypoint.log.
 run_entrypoint() {
+  set +e
   (
     cd "$SANDBOX"
     "$ENTRYPOINT" true
   ) > "$SANDBOX/entrypoint.log" 2>&1
+  ENTRYPOINT_STATUS=$?
+  set -e
 }
 
 assert_npm_called() {
-  if grep -q "^npm install" "$SANDBOX/npm-calls.log"; then
+  if grep -qE "^npm (install|ci)" "$SANDBOX/npm-calls.log"; then
     pass
   else
-    fail "expected npm install to be called; log was: $(cat "$SANDBOX/npm-calls.log")"
+    fail "expected npm install/ci to be called; log was: $(cat "$SANDBOX/npm-calls.log")"
   fi
 }
 
@@ -93,30 +109,47 @@ assert_npm_not_called() {
   fi
 }
 
+assert_npm_ci_called() {
+  if grep -q "^npm ci" "$SANDBOX/npm-calls.log"; then
+    pass
+  else
+    fail "expected npm ci; log was: $(cat "$SANDBOX/npm-calls.log")"
+  fi
+}
+
+assert_npm_install_called() {
+  if grep -q "^npm install" "$SANDBOX/npm-calls.log" && \
+     ! grep -q "^npm ci" "$SANDBOX/npm-calls.log"; then
+    pass
+  else
+    fail "expected npm install (and not npm ci); log was: $(cat "$SANDBOX/npm-calls.log")"
+  fi
+}
+
 # ── Tests ───────────────────────────────────────────────────────────────────
 
 echo "Running frontend entrypoint tests..."
 echo ""
 
-# Scenario 1: fresh container — no node_modules at all.
-begin_test "runs npm install when node_modules is missing"
+# Scenario 1: fresh container — no node_modules at all, lockfile present.
+begin_test "runs npm ci when node_modules is missing and lockfile exists"
 make_sandbox
 touch "$SANDBOX/package.json" "$SANDBOX/package-lock.json"
 run_entrypoint
-assert_npm_called
+assert_npm_ci_called
 cleanup_sandbox
 
 # Scenario 2: stale anonymous volume — node_modules exists but no marker.
-begin_test "runs npm install when install marker is missing"
+begin_test "runs npm ci when install marker is missing"
 make_sandbox
 touch "$SANDBOX/package.json" "$SANDBOX/package-lock.json"
 mkdir -p "$SANDBOX/node_modules"
 run_entrypoint
-assert_npm_called
+assert_npm_ci_called
 cleanup_sandbox
 
 # Scenario 3: regression for #159 — lockfile updated after last install.
-begin_test "runs npm install when package-lock.json is newer than marker"
+begin_test "runs npm ci when package-lock.json is newer than marker"
 make_sandbox
 touch "$SANDBOX/package.json"
 mkdir -p "$SANDBOX/node_modules"
@@ -124,11 +157,11 @@ mkdir -p "$SANDBOX/node_modules"
 touch -t 202001010000 "$SANDBOX/node_modules/.package-lock.json"
 touch -t 202601010000 "$SANDBOX/package-lock.json"
 run_entrypoint
-assert_npm_called
+assert_npm_ci_called
 cleanup_sandbox
 
 # Scenario 4: happy path — deps are already in sync, nothing to do.
-begin_test "skips npm install when marker is newer than lockfile"
+begin_test "skips install when marker is newer than lockfile"
 make_sandbox
 touch "$SANDBOX/package.json"
 mkdir -p "$SANDBOX/node_modules"
@@ -138,7 +171,17 @@ run_entrypoint
 assert_npm_not_called
 cleanup_sandbox
 
-# Scenario 5: entrypoint must exec the CMD passed as argv.
+# Scenario 5: fallback to `npm install` when the lockfile is missing entirely.
+# Covers the "bare package.json" edge case rather than crashing with `npm ci`.
+begin_test "falls back to npm install when package-lock.json is missing"
+make_sandbox
+touch "$SANDBOX/package.json"
+# Deliberately no package-lock.json, no node_modules.
+run_entrypoint
+assert_npm_install_called
+cleanup_sandbox
+
+# Scenario 6: entrypoint must exec the CMD passed as argv.
 begin_test "execs the CMD arguments after the install check"
 make_sandbox
 touch "$SANDBOX/package.json"
@@ -147,12 +190,36 @@ touch "$SANDBOX/node_modules/.package-lock.json"
 touch -t 202001010000 "$SANDBOX/package-lock.json"
 touch -t 202601010000 "$SANDBOX/node_modules/.package-lock.json"
 # Use `sh -c 'echo SENTINEL'` as CMD and verify SENTINEL is printed.
+set +e
 ( cd "$SANDBOX" && "$ENTRYPOINT" sh -c 'echo SENTINEL_ENTRYPOINT_EXEC' ) \
   > "$SANDBOX/entrypoint.log" 2>&1
-if grep -q "SENTINEL_ENTRYPOINT_EXEC" "$SANDBOX/entrypoint.log"; then
+exec_status=$?
+set -e
+if [ "$exec_status" -eq 0 ] && grep -q "SENTINEL_ENTRYPOINT_EXEC" "$SANDBOX/entrypoint.log"; then
   pass
 else
-  fail "CMD was not exec'd; log was: $(cat "$SANDBOX/entrypoint.log")"
+  fail "CMD was not exec'd (status=$exec_status); log was: $(cat "$SANDBOX/entrypoint.log")"
+fi
+cleanup_sandbox
+
+# Scenario 7: fail loudly when no command is supplied.
+# Without this guard, `exec ""` would silently exit 127 in shells that allow
+# it; the entrypoint should print a clear diagnostic and exit non-zero.
+begin_test "errors out when no CMD is provided"
+make_sandbox
+touch "$SANDBOX/package.json"
+mkdir -p "$SANDBOX/node_modules"
+touch "$SANDBOX/node_modules/.package-lock.json"
+touch -t 202001010000 "$SANDBOX/package-lock.json"
+touch -t 202601010000 "$SANDBOX/node_modules/.package-lock.json"
+set +e
+( cd "$SANDBOX" && "$ENTRYPOINT" ) > "$SANDBOX/entrypoint.log" 2>&1
+no_cmd_status=$?
+set -e
+if [ "$no_cmd_status" -ne 0 ] && grep -q "no command provided" "$SANDBOX/entrypoint.log"; then
+  pass
+else
+  fail "expected non-zero exit + diagnostic; status=$no_cmd_status log=$(cat "$SANDBOX/entrypoint.log")"
 fi
 cleanup_sandbox
 

--- a/scripts/test-frontend-entrypoint.sh
+++ b/scripts/test-frontend-entrypoint.sh
@@ -1,0 +1,170 @@
+#!/usr/bin/env bash
+# test-frontend-entrypoint.sh — Unit tests for frontend/docker-entrypoint.sh.
+#
+# Regression coverage for issue #159: the dev-mode anonymous volume at
+# /app/node_modules persisted across rebuilds, so new dependencies added to
+# package.json never made it into the running container. The entrypoint fixes
+# that by running `npm install` whenever package-lock.json is newer than the
+# install marker (or the marker is missing entirely).
+#
+# These tests run the entrypoint in a tmpdir with a fake `npm` on PATH so we
+# can assert whether `npm install` was invoked without touching the real
+# package manager.
+#
+# Usage: bash scripts/test-frontend-entrypoint.sh
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+ENTRYPOINT="$REPO_ROOT/frontend/docker-entrypoint.sh"
+
+if [ ! -x "$ENTRYPOINT" ]; then
+  echo "Error: $ENTRYPOINT is not executable" >&2
+  exit 1
+fi
+
+TESTS_RUN=0
+TESTS_PASSED=0
+TESTS_FAILED=0
+CURRENT_TEST=""
+
+begin_test() {
+  CURRENT_TEST="$1"
+  TESTS_RUN=$((TESTS_RUN + 1))
+}
+
+pass() {
+  TESTS_PASSED=$((TESTS_PASSED + 1))
+  echo "  ✓ $CURRENT_TEST"
+}
+
+fail() {
+  TESTS_FAILED=$((TESTS_FAILED + 1))
+  echo "  ✗ $CURRENT_TEST — $1" >&2
+}
+
+# make_sandbox — set up a tmpdir with a fake `npm` on PATH.
+# The fake npm records every invocation to $SANDBOX/npm-calls.log and
+# creates the install marker when called with `install`.
+make_sandbox() {
+  SANDBOX=$(mktemp -d)
+  mkdir -p "$SANDBOX/bin"
+  cat > "$SANDBOX/bin/npm" <<'EOF'
+#!/bin/sh
+echo "npm $*" >> "$SANDBOX/npm-calls.log"
+if [ "$1" = "install" ]; then
+  mkdir -p node_modules
+  touch node_modules/.package-lock.json
+fi
+EOF
+  chmod +x "$SANDBOX/bin/npm"
+  : > "$SANDBOX/npm-calls.log"
+  export SANDBOX
+  export PATH="$SANDBOX/bin:$PATH"
+}
+
+cleanup_sandbox() {
+  [ -n "${SANDBOX:-}" ] && rm -rf "$SANDBOX"
+  SANDBOX=""
+}
+
+# run_entrypoint — run the entrypoint from inside the sandbox with `true` as CMD.
+# Returns the exit code. Captures stdout/stderr into $SANDBOX/entrypoint.log.
+run_entrypoint() {
+  (
+    cd "$SANDBOX"
+    "$ENTRYPOINT" true
+  ) > "$SANDBOX/entrypoint.log" 2>&1
+}
+
+assert_npm_called() {
+  if grep -q "^npm install" "$SANDBOX/npm-calls.log"; then
+    pass
+  else
+    fail "expected npm install to be called; log was: $(cat "$SANDBOX/npm-calls.log")"
+  fi
+}
+
+assert_npm_not_called() {
+  if [ -s "$SANDBOX/npm-calls.log" ]; then
+    fail "expected npm to NOT be called; log was: $(cat "$SANDBOX/npm-calls.log")"
+  else
+    pass
+  fi
+}
+
+# ── Tests ───────────────────────────────────────────────────────────────────
+
+echo "Running frontend entrypoint tests..."
+echo ""
+
+# Scenario 1: fresh container — no node_modules at all.
+begin_test "runs npm install when node_modules is missing"
+make_sandbox
+touch "$SANDBOX/package.json" "$SANDBOX/package-lock.json"
+run_entrypoint
+assert_npm_called
+cleanup_sandbox
+
+# Scenario 2: stale anonymous volume — node_modules exists but no marker.
+begin_test "runs npm install when install marker is missing"
+make_sandbox
+touch "$SANDBOX/package.json" "$SANDBOX/package-lock.json"
+mkdir -p "$SANDBOX/node_modules"
+run_entrypoint
+assert_npm_called
+cleanup_sandbox
+
+# Scenario 3: regression for #159 — lockfile updated after last install.
+begin_test "runs npm install when package-lock.json is newer than marker"
+make_sandbox
+touch "$SANDBOX/package.json"
+mkdir -p "$SANDBOX/node_modules"
+# Marker exists but is older than the lockfile.
+touch -t 202001010000 "$SANDBOX/node_modules/.package-lock.json"
+touch -t 202601010000 "$SANDBOX/package-lock.json"
+run_entrypoint
+assert_npm_called
+cleanup_sandbox
+
+# Scenario 4: happy path — deps are already in sync, nothing to do.
+begin_test "skips npm install when marker is newer than lockfile"
+make_sandbox
+touch "$SANDBOX/package.json"
+mkdir -p "$SANDBOX/node_modules"
+touch -t 202001010000 "$SANDBOX/package-lock.json"
+touch -t 202601010000 "$SANDBOX/node_modules/.package-lock.json"
+run_entrypoint
+assert_npm_not_called
+cleanup_sandbox
+
+# Scenario 5: entrypoint must exec the CMD passed as argv.
+begin_test "execs the CMD arguments after the install check"
+make_sandbox
+touch "$SANDBOX/package.json"
+mkdir -p "$SANDBOX/node_modules"
+touch "$SANDBOX/node_modules/.package-lock.json"
+touch -t 202001010000 "$SANDBOX/package-lock.json"
+touch -t 202601010000 "$SANDBOX/node_modules/.package-lock.json"
+# Use `sh -c 'echo SENTINEL'` as CMD and verify SENTINEL is printed.
+( cd "$SANDBOX" && "$ENTRYPOINT" sh -c 'echo SENTINEL_ENTRYPOINT_EXEC' ) \
+  > "$SANDBOX/entrypoint.log" 2>&1
+if grep -q "SENTINEL_ENTRYPOINT_EXEC" "$SANDBOX/entrypoint.log"; then
+  pass
+else
+  fail "CMD was not exec'd; log was: $(cat "$SANDBOX/entrypoint.log")"
+fi
+cleanup_sandbox
+
+# ── Summary ─────────────────────────────────────────────────────────────────
+
+echo ""
+echo "─────────────────────────────────────"
+echo "Tests run:    $TESTS_RUN"
+echo "Tests passed: $TESTS_PASSED"
+echo "Tests failed: $TESTS_FAILED"
+echo "─────────────────────────────────────"
+
+if [ "$TESTS_FAILED" -gt 0 ]; then
+  exit 1
+fi


### PR DESCRIPTION
## Summary

The dev-mode anonymous volume at `/app/node_modules` in `docker-compose.dev.yml` persists across `docker compose up --build` cycles. When a new dependency is added to `frontend/package.json`, the rebuilt image's fresh `node_modules` is shadowed by the stale anonymous volume, and the running container crashes with `Module not found` (discovered during E2E work on #134 with `react-markdown`).

This PR adds a `docker-entrypoint.sh` to the frontend `deps` stage that compares `package-lock.json` mtime against `node_modules/.package-lock.json` (the marker npm writes after every successful install) and runs `npm ci` on container start whenever the lockfile is newer or the marker is missing. The anonymous volume still serves its purpose (shielding the container from the host's macOS-native `node_modules`), but stale dependencies are automatically resynced — no manual `docker exec npm install` and no `down -v` required.

- New file: `frontend/docker-entrypoint.sh` — POSIX sh script with up-front empty-CMD guard, install-decision logic (`npm ci` when lockfile present, `npm install` fallback otherwise), and `exec "$@"` passthrough. `npm ci` is preferred because the `/app` bind mount means `npm install` would silently rewrite the host's checked-in lockfile on startup.
- `frontend/Dockerfile` — `deps` stage copies the entrypoint into `/usr/local/bin/` and declares `ENTRYPOINT`. The `production` stage starts `FROM node:20-slim` fresh, so production images are unaffected.
- New file: `scripts/test-frontend-entrypoint.sh` — 7 bash regression tests that sandbox the entrypoint against a fake `npm` on `PATH` and cover: missing `node_modules`, missing marker, stale marker (the #159 regression), fresh marker, missing lockfile fallback, CMD exec passthrough, and up-front missing-CMD error (which also asserts npm was never invoked — the whole point of the guard reorder). Every success-path assertion verifies the entrypoint exited 0 so a post-install crash cannot slip through silently.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Knowledge base contribution
- [ ] Documentation
- [x] Infrastructure / CI
- [ ] Refactoring

## Related Issues

Closes #159

## Test plan

- [x] `make check` passes (backend: 476 tests; frontend: 363 tests + lint, typecheck, build)
- [x] `bash scripts/test-frontend-entrypoint.sh` — 7/7 passing
- [x] `bash scripts/test-worktree-dev.sh` — 56/56 still passing (no regression)
- [x] Built `frontend` image and ran `docker run` directly against the entrypoint across all four decision paths (fresh / stale / up-to-date / lockfile-bump)
- [x] Brought up the full `docker compose -f docker-compose.yml -f docker-compose.dev.yml up -d --build` stack, confirmed `[entrypoint] ... running npm ci...` in frontend logs, verified `http://localhost:3000` renders the home page, then reproduced the exact #159 scenario by `touch frontend/package-lock.json && docker restart issue-159-frontend-1` and confirmed the entrypoint re-ran `npm ci` before `next dev` on restart (no `--build`, no `-V` required)
- [x] Playwright snapshot + screenshot of home page through the Docker-dev stack (`e2e-screenshots/auto-fix-159-home.png`)

## Checklist

- [x] I have run `make check` and all checks pass
- [x] I have added tests for new functionality
- [x] I have updated documentation if needed
- [x] My changes do not introduce new warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)
