### PR TITLE
fix: use selected domain in LLM prompts instead of hardcoded backend engineering

### DIFF
--- a/backend/app/agents/plan_generator.py
+++ b/backend/app/agents/plan_generator.py
@@ -9,7 +9,7 @@ from app.graph.state import (
     Resource,
     slugify_concept,
 )
-from app.knowledge_base.loader import load_knowledge_base
+from app.knowledge_base.loader import get_domain_display_name
 from app.prompts.plan_generator import PLAN_GEN_PROMPT
 from app.services.ai import ainvoke_structured
 
@@ -34,11 +34,8 @@ async def generate_plan(state: AssessmentState) -> dict:
         for node in gap_nodes
     )
 
-    skill_domain = state.get("skill_domain", "backend_engineering")
-    domain_display = load_knowledge_base(skill_domain).display_name
-
     prompt = PLAN_GEN_PROMPT.format(
-        domain=domain_display,
+        domain=get_domain_display_name(state),
         target_level=state.get("target_level", "mid"),
         gap_summary=gap_summary,
     )

--- a/backend/app/agents/plan_generator.py
+++ b/backend/app/agents/plan_generator.py
@@ -9,6 +9,7 @@ from app.graph.state import (
     Resource,
     slugify_concept,
 )
+from app.knowledge_base.loader import load_knowledge_base
 from app.prompts.plan_generator import PLAN_GEN_PROMPT
 from app.services.ai import ainvoke_structured
 
@@ -33,7 +34,11 @@ async def generate_plan(state: AssessmentState) -> dict:
         for node in gap_nodes
     )
 
+    skill_domain = state.get("skill_domain", "backend_engineering")
+    domain_display = load_knowledge_base(skill_domain).display_name
+
     prompt = PLAN_GEN_PROMPT.format(
+        domain=domain_display,
         target_level=state.get("target_level", "mid"),
         gap_summary=gap_summary,
     )

--- a/backend/app/agents/question_generator.py
+++ b/backend/app/agents/question_generator.py
@@ -13,6 +13,7 @@ from app.graph.state import (
     Question,
     bloom_index,
 )
+from app.knowledge_base.loader import load_knowledge_base
 from app.prompts.question_gen import QUESTION_GEN_PROMPT
 from app.services.ai import ainvoke_structured
 
@@ -231,7 +232,11 @@ async def generate_question(state: AssessmentState) -> dict:
 
     performance_signal = build_performance_signal(state)
 
+    skill_domain = state.get("skill_domain", "backend_engineering")
+    domain_display = load_knowledge_base(skill_domain).display_name
+
     prompt = QUESTION_GEN_PROMPT.format(
+        domain=domain_display,
         topic=topic,
         bloom_level=bloom_str,
         used_types=", ".join(used_types) if used_types else "none",

--- a/backend/app/agents/question_generator.py
+++ b/backend/app/agents/question_generator.py
@@ -13,7 +13,7 @@ from app.graph.state import (
     Question,
     bloom_index,
 )
-from app.knowledge_base.loader import load_knowledge_base
+from app.knowledge_base.loader import get_domain_display_name
 from app.prompts.question_gen import QUESTION_GEN_PROMPT
 from app.services.ai import ainvoke_structured
 
@@ -232,11 +232,8 @@ async def generate_question(state: AssessmentState) -> dict:
 
     performance_signal = build_performance_signal(state)
 
-    skill_domain = state.get("skill_domain", "backend_engineering")
-    domain_display = load_knowledge_base(skill_domain).display_name
-
     prompt = QUESTION_GEN_PROMPT.format(
-        domain=domain_display,
+        domain=get_domain_display_name(state),
         topic=topic,
         bloom_level=bloom_str,
         used_types=", ".join(used_types) if used_types else "none",

--- a/backend/app/agents/response_evaluator.py
+++ b/backend/app/agents/response_evaluator.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from app.agents.schemas import EvaluationOutput
 from app.graph.state import AssessmentState, BloomLevel, EvaluationResult
+from app.knowledge_base.loader import load_knowledge_base
 from app.prompts.evaluator import EVALUATOR_PROMPT
 from app.services.ai import ainvoke_structured
 
@@ -14,7 +15,11 @@ async def evaluate_response(state: AssessmentState) -> dict:
     bloom = question.bloom_level
     bloom_str = bloom.value if isinstance(bloom, BloomLevel) else str(bloom)
 
+    skill_domain = state.get("skill_domain", "backend_engineering")
+    domain_display = load_knowledge_base(skill_domain).display_name
+
     prompt = EVALUATOR_PROMPT.format(
+        domain=domain_display,
         topic=question.topic,
         bloom_level=bloom_str,
         question_text=question.text,

--- a/backend/app/agents/response_evaluator.py
+++ b/backend/app/agents/response_evaluator.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from app.agents.schemas import EvaluationOutput
 from app.graph.state import AssessmentState, BloomLevel, EvaluationResult
-from app.knowledge_base.loader import load_knowledge_base
+from app.knowledge_base.loader import get_domain_display_name
 from app.prompts.evaluator import EVALUATOR_PROMPT
 from app.services.ai import ainvoke_structured
 
@@ -15,11 +15,8 @@ async def evaluate_response(state: AssessmentState) -> dict:
     bloom = question.bloom_level
     bloom_str = bloom.value if isinstance(bloom, BloomLevel) else str(bloom)
 
-    skill_domain = state.get("skill_domain", "backend_engineering")
-    domain_display = load_knowledge_base(skill_domain).display_name
-
     prompt = EVALUATOR_PROMPT.format(
-        domain=domain_display,
+        domain=get_domain_display_name(state),
         topic=question.topic,
         bloom_level=bloom_str,
         question_text=question.text,

--- a/backend/app/knowledge_base/loader.py
+++ b/backend/app/knowledge_base/loader.py
@@ -40,6 +40,12 @@ def list_domains() -> list[str]:
     return sorted(_get_domain_paths().keys())
 
 
+def get_domain_display_name(state: dict) -> str:
+    """Resolve the human-readable display name for the domain in an assessment state."""
+    domain = state.get("skill_domain", "backend_engineering")
+    return load_knowledge_base(domain).display_name
+
+
 def clear_cache() -> None:
     """Clear all caches. Useful for tests."""
     global _domain_path_cache

--- a/backend/app/prompts/evaluator.py
+++ b/backend/app/prompts/evaluator.py
@@ -1,4 +1,4 @@
-EVALUATOR_PROMPT = """You are an expert technical evaluator assessing a candidate's response to a {domain} question.
+EVALUATOR_PROMPT = """You are an expert technical evaluator assessing a {domain} candidate's response.
 
 Question asked:
 Topic: {topic}

--- a/backend/app/prompts/evaluator.py
+++ b/backend/app/prompts/evaluator.py
@@ -1,4 +1,4 @@
-EVALUATOR_PROMPT = """You are an expert technical evaluator assessing a candidate's response to a backend engineering question.
+EVALUATOR_PROMPT = """You are an expert technical evaluator assessing a candidate's response to a {domain} question.
 
 Question asked:
 Topic: {topic}

--- a/backend/app/prompts/plan_generator.py
+++ b/backend/app/prompts/plan_generator.py
@@ -1,7 +1,7 @@
 # Used by the assessment pipeline agents (with_structured_output handles format)
 PLAN_GEN_PROMPT = """You are a learning engineer creating a personalized learning plan.
 
-The candidate is targeting "{target_level}" level in {domain}.
+The candidate is targeting "{target_level}" level as a {domain}.
 
 Knowledge gaps (sorted by prerequisite order):
 {gap_summary}

--- a/backend/app/prompts/plan_generator.py
+++ b/backend/app/prompts/plan_generator.py
@@ -1,7 +1,7 @@
 # Used by the assessment pipeline agents (with_structured_output handles format)
 PLAN_GEN_PROMPT = """You are a learning engineer creating a personalized learning plan.
 
-The candidate is targeting "{target_level}" level in backend engineering.
+The candidate is targeting "{target_level}" level in {domain}.
 
 Knowledge gaps (sorted by prerequisite order):
 {gap_summary}

--- a/backend/app/prompts/question_gen.py
+++ b/backend/app/prompts/question_gen.py
@@ -8,7 +8,7 @@ from app.graph.state import BLOOM_LEVEL_GUIDE
 # as untrusted context — never as instructions — and must not leak it back into
 # the candidate-visible question text (SR-01, SR-03 in the story 164 threat
 # model).
-QUESTION_GEN_PROMPT = f"""You are an expert technical interviewer assessing backend engineering skills.
+QUESTION_GEN_PROMPT = f"""You are an expert technical interviewer assessing {{domain}} skills.
 
 Generate ONE focused assessment question for the candidate.
 

--- a/backend/tests/test_agents.py
+++ b/backend/tests/test_agents.py
@@ -7,12 +7,20 @@ from unittest.mock import AsyncMock, patch
 import pytest
 
 from app.agents.knowledge_mapper import update_knowledge_graph
+from app.agents.plan_generator import generate_plan
 from app.agents.question_generator import (
     build_performance_signal,
     generate_question,
 )
 from app.agents.response_evaluator import evaluate_response
-from app.agents.schemas import EvaluationOutput, QuestionOutput
+from app.agents.schemas import (
+    EvaluationOutput,
+    PlanConceptOutput,
+    PlanOutput,
+    PlanPhaseOutput,
+    PlanResourceOutput,
+    QuestionOutput,
+)
 from app.graph.state import (
     BloomLevel,
     EvaluationResult,
@@ -742,3 +750,108 @@ class TestQuestionGenPrompt:
         assert "conceptual" in rendered_prompt
         assert "trade-off" in rendered_prompt
         assert "scenario" not in rendered_prompt
+
+
+class TestDomainInPrompts:
+    """Regression tests: prompts must use the domain from state, not hardcode backend."""
+
+    @pytest.mark.asyncio
+    async def test_question_prompt_uses_frontend_domain(self):
+        mock_output = QuestionOutput(
+            topic="react_hooks",
+            bloom_level="apply",
+            text="Explain useEffect.",
+            question_type="conceptual",
+        )
+
+        state = make_initial_state("test", ["react"], "frontend_engineering")
+        state["current_topic"] = "react_hooks"
+        state["current_bloom_level"] = BloomLevel.apply
+
+        with patch(
+            "app.agents.question_generator.ainvoke_structured", new_callable=AsyncMock
+        ) as mock_invoke:
+            mock_invoke.return_value = mock_output
+            await generate_question(state)
+
+        rendered = mock_invoke.await_args.args[1]
+        assert "Frontend Engineer" in rendered
+        assert "backend engineering" not in rendered.lower()
+
+    @pytest.mark.asyncio
+    async def test_evaluator_prompt_uses_devops_domain(self):
+        mock_output = EvaluationOutput(
+            confidence=0.8,
+            bloom_level="apply",
+            evidence=["Good answer"],
+            reasoning="Solid",
+        )
+
+        state = make_initial_state("test", ["docker"], "devops_engineering")
+        state["question_history"] = [
+            Question(
+                id="q-1",
+                topic="container_fundamentals",
+                bloom_level=BloomLevel.apply,
+                text="Explain containers.",
+                question_type="conceptual",
+            )
+        ]
+        state["response_history"] = [
+            Response(question_id="q-1", text="Containers isolate processes.")
+        ]
+
+        with patch(
+            "app.agents.response_evaluator.ainvoke_structured", new_callable=AsyncMock
+        ) as mock_invoke:
+            mock_invoke.return_value = mock_output
+            await evaluate_response(state)
+
+        rendered = mock_invoke.await_args.args[1]
+        assert "DevOps / Platform Engineer" in rendered
+        assert "backend engineering" not in rendered.lower()
+
+    @pytest.mark.asyncio
+    async def test_plan_prompt_uses_frontend_domain(self):
+        fake_output = PlanOutput(
+            summary="Learn React.",
+            total_hours=10.0,
+            phases=[
+                PlanPhaseOutput(
+                    phase_number=1,
+                    title="React Basics",
+                    rationale="Foundation",
+                    estimated_hours=10.0,
+                    concepts=[
+                        PlanConceptOutput(
+                            name="Hooks",
+                            description="React hooks basics.",
+                            resources=[
+                                PlanResourceOutput(type="article", title="Hooks guide", url=None)
+                            ],
+                        )
+                    ],
+                )
+            ],
+        )
+
+        state = make_initial_state("test", ["react"], "frontend_engineering")
+        state["gap_nodes"] = [
+            KnowledgeNode(
+                concept="react_hooks",
+                confidence=0.2,
+                bloom_level=BloomLevel.apply,
+                prerequisites=[],
+                evidence=[],
+            )
+        ]
+
+        with patch(
+            "app.agents.plan_generator.ainvoke_structured", new_callable=AsyncMock
+        ) as mock_invoke:
+            mock_invoke.return_value = fake_output
+            await generate_plan(state)
+
+        rendered = mock_invoke.await_args.args[1]
+        assert "Frontend Engineer" in rendered
+        assert "backend engineering" not in rendered.lower()


### PR DESCRIPTION
## Summary

All 3 LLM prompt templates (evaluator, plan generator, question generator) were hardcoded to "backend engineering" regardless of the domain the user selected (Backend, Frontend, or DevOps). This meant a Frontend or DevOps candidate was evaluated, questioned, and given a learning plan framed for backend engineering.

- Replaced hardcoded "backend engineering" with a `{domain}` placeholder in all 3 prompt templates
- Each agent now reads `skill_domain` from `AssessmentState` and resolves the display name via `load_knowledge_base()` (already cached)
- Added 3 regression tests verifying the correct domain appears in rendered prompts for frontend and devops domains

## Type of Change

- [x] Bug fix

## Related Issues

Closes #172

## Test plan

- [x] `make check` passes (lint + typecheck + test + build)
- [x] 3 new regression tests in `TestDomainInPrompts` verify prompt content for frontend/devops domains
- [x] All 41 existing agent tests continue to pass (they use `backend_engineering` and still work via fallback default)

## Checklist

- [x] I have run `make check` and all checks pass
- [x] I have added tests for new functionality
- [x] I have updated documentation if needed
- [x] My changes do not introduce new warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)